### PR TITLE
[10.0] [ADD] l10n_lu_mis_reports: VAT template

### DIFF
--- a/l10n_lu_mis_reports/__manifest__.py
+++ b/l10n_lu_mis_reports/__manifest__.py
@@ -15,6 +15,7 @@
         'mis_builder',  # OCA/account-financial-reporting
     ],
     'data': [
+        'data/mis_report_vat.xml',
         'data/mis_report_styles.xml',
         'data/mis_report_pl.xml',
         'data/mis_report_bs.xml',

--- a/l10n_lu_mis_reports/data/mis_report_vat.xml
+++ b/l10n_lu_mis_reports/data/mis_report_vat.xml
@@ -1,0 +1,6819 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 Acsone SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+    <record id="mis_report_vat" model="mis.report">
+      <field name="name">VAT 2015</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_12</field>
+      <field name="description">Base - Achat Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">10</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_12</field>
+      <field name="description">Base - Achat Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">20</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_12</field>
+      <field name="description">Base - Achat Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">30</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_14</field>
+      <field name="description">Base - Achat Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">40</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_14</field>
+      <field name="description">Base - Achat Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">50</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_14</field>
+      <field name="description">Base - Achat Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">60</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_15</field>
+      <field name="description">Base - Achat Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">70</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_15</field>
+      <field name="description">Base - Achat Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">80</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_15</field>
+      <field name="description">Base - Achat Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">90</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_17</field>
+      <field name="description">Base - Achat Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_17</field>
+      <field name="description">Base - Achat Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_17</field>
+      <field name="description">Base - Achat Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_3</field>
+      <field name="description">Base - Achat Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_3</field>
+      <field name="description">Base - Achat Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_3</field>
+      <field name="description">Base - Achat Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_6</field>
+      <field name="description">Base - Achat Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_6</field>
+      <field name="description">Base - Achat Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_6</field>
+      <field name="description">Base - Achat Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">180</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_8</field>
+      <field name="description">Base - Achat Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_8</field>
+      <field name="description">Base - Achat Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">200</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_8</field>
+      <field name="description">Base - Achat Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">210</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_EC_0</field>
+      <field name="description">Base - Achat Biens Exonéré - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_ECP_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_ECP_0</field>
+      <field name="description">Base - Achat Biens Exonéré - Extracommunautaire fin privées</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_IC_0</field>
+      <field name="description">Base - Achat Biens Exonéré - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_12</field>
+      <field name="description">Base - Achat Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_12</field>
+      <field name="description">Base - Achat Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_14</field>
+      <field name="description">Base - Achat Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_14</field>
+      <field name="description">Base - Achat Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_15</field>
+      <field name="description">Base - Achat Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">290</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_15</field>
+      <field name="description">Base - Achat Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_17</field>
+      <field name="description">Base - Achat Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_17</field>
+      <field name="description">Base - Achat Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_3</field>
+      <field name="description">Base - Achat Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_3</field>
+      <field name="description">Base - Achat Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_6</field>
+      <field name="description">Base - Achat Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_6</field>
+      <field name="description">Base - Achat Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_8</field>
+      <field name="description">Base - Achat Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_8</field>
+      <field name="description">Base - Achat Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_EC_0</field>
+      <field name="description">Base - Achat Prestations Exonérées - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_IC_0</field>
+      <field name="description">Base - Achat Prestations Exonérées - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_12</field>
+      <field name="description">Base - Frais Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_12</field>
+      <field name="description">Base - Frais Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_12</field>
+      <field name="description">Base - Frais Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_14</field>
+      <field name="description">Base - Frais Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_14</field>
+      <field name="description">Base - Frais Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_14</field>
+      <field name="description">Base - Frais Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_15</field>
+      <field name="description">Base - Frais Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_15</field>
+      <field name="description">Base - Frais Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_15</field>
+      <field name="description">Base - Frais Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_17</field>
+      <field name="description">Base - Frais Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_17</field>
+      <field name="description">Base - Frais Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_17</field>
+      <field name="description">Base - Frais Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_3</field>
+      <field name="description">Base - Frais Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_3</field>
+      <field name="description">Base - Frais Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_3</field>
+      <field name="description">Base - Frais Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_6</field>
+      <field name="description">Base - Frais Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_6</field>
+      <field name="description">Base - Frais Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_6</field>
+      <field name="description">Base - Frais Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_8</field>
+      <field name="description">Base - Frais Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_8</field>
+      <field name="description">Base - Frais Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_8</field>
+      <field name="description">Base - Frais Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_EC_0</field>
+      <field name="description">Base - Frais Biens Exonéré - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_ECP_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_ECP_0</field>
+      <field name="description">Base - Frais Biens Exonéré - Extracommunautaire fin privées</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_IC_0</field>
+      <field name="description">Base - Frais Biens Exonéré - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">640</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_12</field>
+      <field name="description">Base - Frais Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">650</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_12</field>
+      <field name="description">Base - Frais Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_14</field>
+      <field name="description">Base - Frais Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_14</field>
+      <field name="description">Base - Frais Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_15</field>
+      <field name="description">Base - Frais Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_15</field>
+      <field name="description">Base - Frais Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_17</field>
+      <field name="description">Base - Frais Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_17</field>
+      <field name="description">Base - Frais Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_3</field>
+      <field name="description">Base - Frais Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_3</field>
+      <field name="description">Base - Frais Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_6</field>
+      <field name="description">Base - Frais Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_6</field>
+      <field name="description">Base - Frais Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_8</field>
+      <field name="description">Base - Frais Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_8</field>
+      <field name="description">Base - Frais Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_EC_0</field>
+      <field name="description">Base - Frais Prestations Exonérées - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_IC_0</field>
+      <field name="description">Base - Frais Prestations Exonérées - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_12</field>
+      <field name="description">Base - Investissement Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_12</field>
+      <field name="description">Base - Investissement Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_12</field>
+      <field name="description">Base - Investissement Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_14</field>
+      <field name="description">Base - Investissement Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_14</field>
+      <field name="description">Base - Investissement Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_14</field>
+      <field name="description">Base - Investissement Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_15</field>
+      <field name="description">Base - Investissement Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_15</field>
+      <field name="description">Base - Investissement Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_15</field>
+      <field name="description">Base - Investissement Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_17</field>
+      <field name="description">Base - Investissement Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_17</field>
+      <field name="description">Base - Investissement Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_17</field>
+      <field name="description">Base - Investissement Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_3</field>
+      <field name="description">Base - Investissement Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">930</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_3</field>
+      <field name="description">Base - Investissement Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">940</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_3</field>
+      <field name="description">Base - Investissement Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">950</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_6</field>
+      <field name="description">Base - Investissement Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">960</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_6</field>
+      <field name="description">Base - Investissement Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">970</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_6</field>
+      <field name="description">Base - Investissement Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">980</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_8</field>
+      <field name="description">Base - Investissement Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">990</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_8</field>
+      <field name="description">Base - Investissement Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1000</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_8</field>
+      <field name="description">Base - Investissement Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1010</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_EC_0</field>
+      <field name="description">Base - Investissement Biens Exonéré - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1020</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_ECP_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_ECP_0</field>
+      <field name="description">Base - Investissement Biens Exonéré - Extracommunautaire fin privées</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1030</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_IC_0</field>
+      <field name="description">Base - Investissement Biens Exonéré - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1040</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_12</field>
+      <field name="description">Base - Investissement Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1050</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_12</field>
+      <field name="description">Base - Investissement Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1060</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_14</field>
+      <field name="description">Base - Investissement Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1070</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_14</field>
+      <field name="description">Base - Investissement Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1080</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_15</field>
+      <field name="description">Base - Investissement Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1090</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_15</field>
+      <field name="description">Base - Investissement Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_17</field>
+      <field name="description">Base - Investissement Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_17</field>
+      <field name="description">Base - Investissement Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_3</field>
+      <field name="description">Base - Investissement Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_3</field>
+      <field name="description">Base - Investissement Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_6</field>
+      <field name="description">Base - Investissement Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_6</field>
+      <field name="description">Base - Investissement Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_8</field>
+      <field name="description">Base - Investissement Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_8</field>
+      <field name="description">Base - Investissement Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1180</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_EC_0</field>
+      <field name="description">Base - Investissement Prestations Exonérées - Extracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_IC_0</field>
+      <field name="description">Base - Investissement Prestations Exonérées - Intracommunautaire</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1200</field>
+    </record>
+    <record id="mis_report_vat_ecdf_051" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_051</field>
+      <field name="description">II.B. Acquisitions intracommunautaires de biens – base</field>
+      <field name="expression">+ecdf_047+ecdf_048+ecdf_049+ecdf_050+ecdf_194+ecdf_711+ecdf_713+ecdf_715</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1210</field>
+    </record>
+    <record id="mis_report_vat_ecdf_050" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_050</field>
+      <field name="description">II.B. base 12%</field>
+      <field name="expression">+ecdf_b_AB_IC_12+ecdf_b_FB_IC_12+ecdf_b_IB_IC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_713" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_713</field>
+      <field name="description">II.B. base 14%</field>
+      <field name="expression">+ecdf_b_AB_IC_14+ecdf_b_FB_IC_14+ecdf_b_IB_IC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_047" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_047</field>
+      <field name="description">II.B. base 15%</field>
+      <field name="expression">+ecdf_b_AB_IC_15+ecdf_b_FB_IC_15+ecdf_b_IB_IC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_711" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_711</field>
+      <field name="description">II.B. base 17%</field>
+      <field name="expression">+ecdf_b_AB_IC_17+ecdf_b_FB_IC_17+ecdf_b_IB_IC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_049" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_049</field>
+      <field name="description">II.B. base 3%</field>
+      <field name="expression">+ecdf_b_AB_IC_3+ecdf_b_FB_IC_3+ecdf_b_IB_IC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_048" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_048</field>
+      <field name="description">II.B. base 6%</field>
+      <field name="expression">+ecdf_b_AB_IC_6+ecdf_b_FB_IC_6+ecdf_b_IB_IC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_715" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_715</field>
+      <field name="description">II.B. base 8%</field>
+      <field name="expression">+ecdf_b_AB_IC_8+ecdf_b_FB_IC_8+ecdf_b_IB_IC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_194" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_194</field>
+      <field name="description">II.B. base exonérée</field>
+      <field name="expression">+ecdf_b_AB_IC_0+ecdf_b_FB_IC_0+ecdf_b_IB_IC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1290</field>
+    </record>
+    <record id="mis_report_vat_ext_152" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_152</field>
+      <field name="description">II.C. Acquisitions effectuées dans le cadre d'opérations triangulaires – base</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_060" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_060</field>
+      <field name="description">II.D.1. base 12%</field>
+      <field name="expression">+ecdf_b_AB_EC_12+ecdf_b_FB_EC_12+ecdf_b_IB_EC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_723" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_723</field>
+      <field name="description">II.D.1. base 14%</field>
+      <field name="expression">+ecdf_b_AB_EC_14+ecdf_b_FB_EC_14+ecdf_b_IB_EC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_057" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_057</field>
+      <field name="description">II.D.1. base 15%</field>
+      <field name="expression">+ecdf_b_AB_EC_15+ecdf_b_FB_EC_15+ecdf_b_IB_EC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_721" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_721</field>
+      <field name="description">II.D.1. base 17%</field>
+      <field name="expression">+ecdf_b_AB_EC_17+ecdf_b_FB_EC_17+ecdf_b_IB_EC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_059" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_059</field>
+      <field name="description">II.D.1. base 3%</field>
+      <field name="expression">+ecdf_b_AB_EC_3+ecdf_b_FB_EC_3+ecdf_b_IB_EC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_058" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_058</field>
+      <field name="description">II.D.1. base 6%</field>
+      <field name="expression">+ecdf_b_AB_EC_6+ecdf_b_FB_EC_6+ecdf_b_IB_EC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_725" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_725</field>
+      <field name="description">II.D.1. base 8%</field>
+      <field name="expression">+ecdf_b_AB_EC_8+ecdf_b_FB_EC_8+ecdf_b_IB_EC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_195" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_195</field>
+      <field name="description">II.D.1. base exonérée</field>
+      <field name="expression">+ecdf_b_AB_EC_0+ecdf_b_FB_EC_0+ecdf_b_IB_EC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_064" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_064</field>
+      <field name="description">II.D.2.. base 12%</field>
+      <field name="expression">+ecdf_b_AB_ECP_12+ecdf_b_FB_ECP_12+ecdf_b_IB_ECP_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_733" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_733</field>
+      <field name="description">II.D.2.. base 14%</field>
+      <field name="expression">+ecdf_b_AB_ECP_14+ecdf_b_FB_ECP_14+ecdf_b_IB_ECP_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_061" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_061</field>
+      <field name="description">II.D.2.. base 15%</field>
+      <field name="expression">+ecdf_b_AB_ECP_15+ecdf_b_FB_ECP_15+ecdf_b_IB_ECP_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_731" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_731</field>
+      <field name="description">II.D.2.. base 17%</field>
+      <field name="expression">+ecdf_b_AB_ECP_17+ecdf_b_FB_ECP_17+ecdf_b_IB_ECP_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_063" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_063</field>
+      <field name="description">II.D.2.. base 3%</field>
+      <field name="expression">+ecdf_b_AB_ECP_3+ecdf_b_FB_ECP_3+ecdf_b_IB_ECP_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_062" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_062</field>
+      <field name="description">II.D.2.. base 6%</field>
+      <field name="expression">+ecdf_b_AB_ECP_6+ecdf_b_FB_ECP_6+ecdf_b_IB_ECP_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_735" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_735</field>
+      <field name="description">II.D.2.. base 8%</field>
+      <field name="expression">+ecdf_b_AB_ECP_8+ecdf_b_FB_ECP_8+ecdf_b_IB_ECP_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_196" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_196</field>
+      <field name="description">II.D.2.. base exonérée</field>
+      <field name="expression">+ecdf_b_AB_ECP_0+ecdf_b_FB_ECP_0+ecdf_b_IB_ECP_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_065" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_065</field>
+      <field name="description">II.D. Importations de biens – base</field>
+      <field name="expression">+ecdf_057+ecdf_058+ecdf_059+ecdf_060+ecdf_061+ecdf_062+ecdf_063+ecdf_064+ecdf_195+ecdf_196+ecdf_721+ecdf_723+ecdf_725+ecdf_731+ecdf_733+ecdf_735</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_433" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_433</field>
+      <field name="description">II.E.1.a) base 12%</field>
+      <field name="expression">+ecdf_b_AP_IC_12+ecdf_b_FP_IC_12+ecdf_b_IP_IC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_743" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_743</field>
+      <field name="description">II.E.1.a) base 14%</field>
+      <field name="expression">+ecdf_b_AP_IC_14+ecdf_b_FP_IC_14+ecdf_b_IP_IC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_427" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_427</field>
+      <field name="description">II.E.1.a) base 15%</field>
+      <field name="expression">+ecdf_b_AP_IC_15+ecdf_b_FP_IC_15+ecdf_b_IP_IC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_741" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_741</field>
+      <field name="description">II.E.1.a) base 17%</field>
+      <field name="expression">+ecdf_b_AP_IC_17+ecdf_b_FP_IC_17+ecdf_b_IP_IC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_431" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_431</field>
+      <field name="description">II.E.1.a) base 3%</field>
+      <field name="expression">+ecdf_b_AP_IC_3+ecdf_b_FP_IC_3+ecdf_b_IP_IC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_429" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_429</field>
+      <field name="description">II.E.1.a) base 6%</field>
+      <field name="expression">+ecdf_b_AP_IC_6+ecdf_b_FP_IC_6+ecdf_b_IP_IC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_745" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_745</field>
+      <field name="description">II.E.1.a) base 8%</field>
+      <field name="expression">+ecdf_b_AP_IC_8+ecdf_b_FP_IC_8+ecdf_b_IP_IC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_436" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_436</field>
+      <field name="description">II.E.1. base</field>
+      <field name="expression">+ecdf_427+ecdf_429+ecdf_431+ecdf_433+ecdf_435+ecdf_741+ecdf_743+ecdf_745</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_435" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_435</field>
+      <field name="description">II.E.1.b) exonérées</field>
+      <field name="expression">+ecdf_b_AP_IC_0+ecdf_b_FP_IC_0+ecdf_b_IP_IC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_463" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_463</field>
+      <field name="description">II.E.2. base</field>
+      <field name="expression">+ecdf_437+ecdf_439+ecdf_441+ecdf_443+ecdf_445+ecdf_751+ecdf_753+ecdf_755</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_443" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_443</field>
+      <field name="description">II.E.2. base 12%</field>
+      <field name="expression">+ecdf_b_AP_EC_12+ecdf_b_FP_EC_12+ecdf_b_IP_EC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_753" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_753</field>
+      <field name="description">II.E.2. base 14%</field>
+      <field name="expression">+ecdf_b_AP_EC_14+ecdf_b_FP_EC_14+ecdf_b_IP_EC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_437" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_437</field>
+      <field name="description">II.E.2. base 15%</field>
+      <field name="expression">+ecdf_b_AP_EC_15+ecdf_b_FP_EC_15+ecdf_b_IP_EC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_751" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_751</field>
+      <field name="description">II.E.2. base 17%</field>
+      <field name="expression">+ecdf_b_AP_EC_17+ecdf_b_FP_EC_17+ecdf_b_IP_EC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_441" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_441</field>
+      <field name="description">II.E.2. base 3%</field>
+      <field name="expression">+ecdf_b_AP_EC_3+ecdf_b_FP_EC_3+ecdf_b_IP_EC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_439" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_439</field>
+      <field name="description">II.E.2. base 6%</field>
+      <field name="expression">+ecdf_b_AP_EC_6+ecdf_b_FP_EC_6+ecdf_b_IP_EC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_755" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_755</field>
+      <field name="description">II.E.2. base 8%</field>
+      <field name="expression">+ecdf_b_AP_EC_8+ecdf_b_FP_EC_8+ecdf_b_IP_EC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1640</field>
+    </record>
+    <record id="mis_report_vat_ecdf_445" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_445</field>
+      <field name="description">II.E.2. exonérées</field>
+      <field name="expression">+ecdf_b_AP_EC_0+ecdf_b_FP_EC_0+ecdf_b_IP_EC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1650</field>
+    </record>
+    <record id="mis_report_vat_ecdf_765" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_765</field>
+      <field name="description">II.E.3. base</field>
+      <field name="expression">ecdf_761+ecdf_420</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1551</field>
+    </record>
+    <record id="mis_report_vat_ext_761" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_761</field>
+      <field name="description">II.E.3. base 17%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1652</field>
+    </record>
+    <record id="mis_report_vat_ext_420" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_420</field>
+      <field name="description">II.E.3. base 15%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1653</field>
+    </record>
+    <record id="mis_report_vat_ecdf_409" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_409</field>
+      <field name="description">II.E. Prestations de services à déclarer par le preneur redevable de la taxe – base</field>
+      <field name="expression">+ecdf_436+ecdf_463+ecdf_765+ecdf_435</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_767" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_767</field>
+      <field name="description">II.F. Livraisons de biens à déclarer par l'acquéreur redevable de la taxe – base</field>
+      <field name="expression">+ecdf_763+ecdf_222</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1661</field>
+    </record>
+    <record id="mis_report_vat_ext_763" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_763</field>
+      <field name="description">II.F. base 8%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1662</field>
+    </record>
+    <record id="mis_report_vat_ext_222" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_222</field>
+      <field name="description">II.F. base 6%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1663</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_V_ART_43_60b" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_V_ART_43_60b</field>
+      <field name="description">Base - Vente - Autres Exonérations (Article 43 et 60 bis)</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'V-ART-43_60b')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_V_ART_44_56q" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_V_ART_44_56q</field>
+      <field name="description">Base - Vente - Autres Exonérations (Article 44 et 56 quarter)</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'V-ART-44_56q')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_0</field>
+      <field name="description">Base - Vente Biens 0% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_12</field>
+      <field name="description">Base - Vente Biens 12% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_14</field>
+      <field name="description">Base - Vente Biens 14% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_15</field>
+      <field name="description">Base - Vente Biens 15% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_17</field>
+      <field name="description">Base - Vente Biens 17% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_3</field>
+      <field name="description">Base - Vente Biens 3% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_6</field>
+      <field name="description">Base - Vente Biens 6% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_8</field>
+      <field name="description">Base - Vente Biens 8% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_EC_0</field>
+      <field name="description">Base - Vente Biens - Extracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_IC_0</field>
+      <field name="description">Base - Vente Biens - Intracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_EC_Tab" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_EC_Tab</field>
+      <field name="description">Base - Vente Biens Tabacs - Extracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-EC-Tab')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_IC_Tab" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_IC_Tab</field>
+      <field name="description">Base - Vente Biens Tabacs - Intracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-IC-Tab')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_PA_Tab" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_PA_Tab</field>
+      <field name="description">Base - Vente Biens Tabacs - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-Tab')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VB_TR_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VB_TR_0</field>
+      <field name="description">Base - Vente Biens – Triangulaire Intracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-TR-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_0</field>
+      <field name="description">Base - Vente Prestations 0% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_12</field>
+      <field name="description">Base - Vente Prestations 12% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_14</field>
+      <field name="description">Base - Vente Prestations 14% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_15</field>
+      <field name="description">Base - Vente Prestations 15% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_17</field>
+      <field name="description">Base - Vente Prestations 17% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_3</field>
+      <field name="description">Base - Vente Prestations 3% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_6</field>
+      <field name="description">Base - Vente Prestations 6% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_PA_8</field>
+      <field name="description">Base - Vente Prestations 8% - Pays</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_EC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_EC_0</field>
+      <field name="description">Base - Vente Prestations - Extracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-EC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_IC_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_IC_0</field>
+      <field name="description">Base - Vente Prestations - Intracommunautaire</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-IC-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_VP_IC_EX" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_VP_IC_EX</field>
+      <field name="description">Base - Vente Prestations - Intracommunautaire exonérées dans l'état membre</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-IC-EX')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1930</field>
+    </record>
+    <record id="mis_report_vat_ecdf_012" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_012</field>
+      <field name="description">I.A. Chiffre d'affaires global</field>
+      <field name="expression">+ecdf_454+ecdf_455+ecdf_456</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1940</field>
+    </record>
+    <record id="mis_report_vat_ext_454" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_454</field>
+      <field name="description">I.A.2. Total des Ventes / Recettes</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1941</field>
+    </record>
+    <record id="mis_report_vat_ext_455" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_455</field>
+      <field name="description">I.A.3. Prélèvements privés de biens et affectation de biens (art.13)</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1942</field>
+    </record>
+    <record id="mis_report_vat_ext_456" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_456</field>
+      <field name="description">I.A.4. Utilisation privée de biens et prélèvements privés de services (art.16) </field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1943</field>
+     </record>
+    <record id="mis_report_vat_ecdf_457" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_457</field>
+      <field name="description">I.B.1. Livraisons intracommunautaires de biens à des personnes identifiées à la TVA dans un autre Etat membre (art.43/1/d,e et f) (3)</field>
+      <field name="expression">+ecdf_b_VB_IC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1950</field>
+    </record>
+    <record id="mis_report_vat_ecdf_014" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_014</field>
+      <field name="description">I.B.2. Exportations (art.43/1/a et b)</field>
+      <field name="expression">+ecdf_b_VB_EC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1960</field>
+    </record>
+    <record id="mis_report_vat_ecdf_015" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_015</field>
+      <field name="description">I.B.3. Autres exonérations (art.43 et 60bis)</field>
+      <field name="expression">+ecdf_b_V_ART_43_60b</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1970</field>
+    </record>
+    <record id="mis_report_vat_ecdf_016" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_016</field>
+      <field name="description">I.B.4. Autres exonérations (art.44 et 56quater)</field>
+      <field name="expression">+ecdf_b_V_ART_44_56q</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1980</field>
+    </record>
+    <record id="mis_report_vat_ecdf_017" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_017</field>
+      <field name="description">I.B.5. Tabacs fabriqués</field>
+      <field name="expression">+ecdf_b_VB_EC_Tab+ecdf_b_VB_IC_Tab+ecdf_b_VB_PA_Tab</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">1990</field>
+    </record>
+    <record id="mis_report_vat_ecdf_018" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_018</field>
+      <field name="description">I.B.6.a) Livraisons subséquentes à des acquisitions intracommunautaires dans le cadre d'opérations triangulaires, lorsque le destinataire identifié à la TVA dans l'Etat membre de destination des biens y est le redevable de la taxe (4)</field>
+      <field name="expression">+ecdf_b_VB_TR_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2000</field>
+    </record>
+    <record id="mis_report_vat_ecdf_423" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_423</field>
+      <field name="description">I.B.6.b)1)  Prestations de services à des identifiés à la TVA dans un autre Etat membre non exonérées dans l'Etat membre du preneur redevable (art.17/1/b) (5)</field>
+      <field name="expression">+ecdf_b_VP_IC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2010</field>
+    </record>
+    <record id="mis_report_vat_ecdf_424" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_424</field>
+      <field name="description">I.B.6.b)2)  Prestations de services à des identifiés à la TVA dans un autre Etat membre exonérées dans l'Etat membre du preneur (art.17/1/b)</field>
+      <field name="expression">+ecdf_b_VP_IC_EX</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2020</field>
+    </record>
+    <record id="mis_report_vat_ext_226" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_226</field>
+      <field name="description">I.B.6.c) Opérations réalisées dans le cadre du régime particulier de l'article 56sexies</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2030</field>
+    </record>
+    <record id="mis_report_vat_ecdf_019" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_019</field>
+      <field name="description">I.B.6.d) Autres opérations réalisées (imposables) à l'étranger</field>
+      <field name="expression">+ecdf_b_VP_EC_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2040</field>
+    </record>
+    <record id="mis_report_vat_ext_419" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_419</field>
+      <field name="description">I.B.7. Opérations à l'intérieur du pays pour lesquelles le preneur est le redevable</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2050</field>
+    </record>
+    <record id="mis_report_vat_ecdf_021" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_021</field>
+      <field name="description">I.B. Exonérations et montants déductibles</field>
+      <field name="expression">+ecdf_014+ecdf_015+ecdf_016+ecdf_017+ecdf_018+ecdf_019+ecdf_226+ecdf_419+ecdf_423+ecdf_424+ecdf_457</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2060</field>
+    </record>
+    <record id="mis_report_vat_ecdf_022" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_022</field>
+      <field name="description">I.C. Chiffre d'affaires imposable</field>
+      <field name="expression">+ecdf_037</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2070</field>
+    </record>
+    <record id="mis_report_vat_ecdf_403" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_403</field>
+      <field name="description">II.A 0%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2071</field>
+    </record>
+    <record id="mis_report_vat_ext_418" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_418</field>
+      <field name="description">II.A _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2072</field>
+    </record>
+    <record id="mis_report_vat_ext_453" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_453</field>
+      <field name="description">II.A _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2073</field>
+    </record>
+    <record id="mis_report_vat_ecdf_033" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_033</field>
+      <field name="description">II.A. base 0%</field>
+      <field name="expression">+ecdf_b_VB_PA_0+ecdf_b_VP_PA_0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2080</field>
+    </record>
+    <record id="mis_report_vat_ext_416" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_416</field>
+      <field name="description">II.A. base _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2081</field>
+    </record>
+    <record id="mis_report_vat_ext_451" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_451</field>
+      <field name="description">II.A. base _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2082</field>
+    </record>
+    <record id="mis_report_vat_ecdf_032" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_032</field>
+      <field name="description">II.A. base 12%</field>
+      <field name="expression">+ecdf_b_VB_PA_12+ecdf_b_VP_PA_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2090</field>
+    </record>
+    <record id="mis_report_vat_ecdf_703" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_703</field>
+      <field name="description">II.A. base 14%</field>
+      <field name="expression">+ecdf_b_VB_PA_14+ecdf_b_VP_PA_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_029" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_029</field>
+      <field name="description">II.A. base 15%</field>
+      <field name="expression">+ecdf_b_VB_PA_15+ecdf_b_VP_PA_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_701" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_701</field>
+      <field name="description">II.A. base 17%</field>
+      <field name="expression">+ecdf_b_VB_PA_17+ecdf_b_VP_PA_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_031" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_031</field>
+      <field name="description">II.A. base 3%</field>
+      <field name="expression">+ecdf_b_VB_PA_3+ecdf_b_VP_PA_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_030" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_030</field>
+      <field name="description">II.A. base 6%</field>
+      <field name="expression">+ecdf_b_VB_PA_6+ecdf_b_VP_PA_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_705" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_705</field>
+      <field name="description">II.A. base 8%</field>
+      <field name="expression">+ecdf_b_VB_PA_8+ecdf_b_VP_PA_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_037" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_037</field>
+      <field name="description">II.A. Ventilation du chiffre d'affaires imposable – base</field>
+      <field name="expression">+ecdf_029+ecdf_030+ecdf_031+ecdf_032+ecdf_033+ecdf_701+ecdf_703+ecdf_705+ecdf_416+ecdf_451</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_0</field>
+      <field name="description">Base - Achat Biens 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_12</field>
+      <field name="description">Base - Achat Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2180</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_14</field>
+      <field name="description">Base - Achat Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_15</field>
+      <field name="description">Base - Achat Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2200</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_17</field>
+      <field name="description">Base - Achat Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2210</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_3</field>
+      <field name="description">Base - Achat Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_6</field>
+      <field name="description">Base - Achat Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AB_PA_8</field>
+      <field name="description">Base - Achat Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_0</field>
+      <field name="description">Base - Achat Prestations 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_12</field>
+      <field name="description">Base - Achat Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_14</field>
+      <field name="description">Base - Achat Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_15</field>
+      <field name="description">Base - Achat Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_17</field>
+      <field name="description">Base - Achat Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2290</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_3</field>
+      <field name="description">Base - Achat Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_6</field>
+      <field name="description">Base - Achat Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_AP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_AP_PA_8</field>
+      <field name="description">Base - Achat Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_0</field>
+      <field name="description">Base - Frais Biens 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_12</field>
+      <field name="description">Base - Frais Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_14</field>
+      <field name="description">Base - Frais Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_15</field>
+      <field name="description">Base - Frais Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_17</field>
+      <field name="description">Base - Frais Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_3</field>
+      <field name="description">Base - Frais Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_6</field>
+      <field name="description">Base - Frais Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FB_PA_8</field>
+      <field name="description">Base - Frais Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_0</field>
+      <field name="description">Base - Frais Prestations 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_12</field>
+      <field name="description">Base - Frais Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_14</field>
+      <field name="description">Base - Frais Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_15</field>
+      <field name="description">Base - Frais Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_17</field>
+      <field name="description">Base - Frais Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_3</field>
+      <field name="description">Base - Frais Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_6</field>
+      <field name="description">Base - Frais Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_FP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_FP_PA_8</field>
+      <field name="description">Base - Frais Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_0</field>
+      <field name="description">Base - Investissement Biens 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_12</field>
+      <field name="description">Base - Investissement Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_14</field>
+      <field name="description">Base - Investissement Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_15</field>
+      <field name="description">Base - Investissement Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_17</field>
+      <field name="description">Base - Investissement Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_3</field>
+      <field name="description">Base - Investissement Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_6</field>
+      <field name="description">Base - Investissement Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IB_PA_8</field>
+      <field name="description">Base - Investissement Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_0" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_0</field>
+      <field name="description">Base - Investissement Prestations 0% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-0')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_12</field>
+      <field name="description">Base - Investissement Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_14</field>
+      <field name="description">Base - Investissement Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_15</field>
+      <field name="description">Base - Investissement Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_17</field>
+      <field name="description">Base - Investissement Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_3</field>
+      <field name="description">Base - Investissement Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_6</field>
+      <field name="description">Base - Investissement Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_b_IP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_b_IP_PA_8</field>
+      <field name="description">Base - Investissement Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2640</field>
+    </record>
+    <record id="mis_report_vat_b_SANS" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">b_SANS</field>
+      <field name="description">Base - Sans Taxe</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-SANS')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2650</field>
+    </record>
+    <record id="mis_report_vat_ext_042" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_042</field>
+      <field name="description">II.A. taxe 0%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2660</field>
+    </record>
+    <record id="mis_report_vat_ext_417" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_417</field>
+      <field name="description">II.A. taxe _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2660</field>
+    </record>
+    <record id="mis_report_vat_ext_452" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_452</field>
+      <field name="description">II.A. taxe _%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_041" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_041</field>
+      <field name="description">II.A. taxe 12%</field>
+      <field name="expression">+ecdf_t_VB_PA_12+ecdf_t_VP_PA_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_704" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_704</field>
+      <field name="description">II.A. taxe 14%</field>
+      <field name="expression">+ecdf_t_VB_PA_14+ecdf_t_VP_PA_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_038" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_038</field>
+      <field name="description">II.A. taxe 15%</field>
+      <field name="expression">+ecdf_t_VB_PA_15+ecdf_t_VP_PA_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_702" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_702</field>
+      <field name="description">II.A. taxe 17%</field>
+      <field name="expression">+ecdf_t_VB_PA_17+ecdf_t_VP_PA_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_040" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_040</field>
+      <field name="description">II.A. taxe 3%</field>
+      <field name="expression">+ecdf_t_VB_PA_3+ecdf_t_VP_PA_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_039" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_039</field>
+      <field name="description">II.A. taxe 6%</field>
+      <field name="expression">+ecdf_t_VB_PA_6+ecdf_t_VP_PA_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_706" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_706</field>
+      <field name="description">II.A. taxe 8%</field>
+      <field name="expression">+ecdf_t_VB_PA_8+ecdf_t_VP_PA_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_046" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_046</field>
+      <field name="description">II.A. Ventilation du chiffre d'affaires imposable – taxe</field>
+      <field name="expression">+ecdf_038+ecdf_039+ecdf_040+ecdf_041+ecdf_042+ecdf_702+ecdf_704+ecdf_706+ecdf_417+ecdf_452</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_056" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_056</field>
+      <field name="description">II.B. Acquisitions intracommunautaires de biens – taxe</field>
+      <field name="expression">+ecdf_052+ecdf_053+ecdf_054+ecdf_055+ecdf_712+ecdf_714+ecdf_716</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_055" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_055</field>
+      <field name="description">II.B. taxe 12%</field>
+      <field name="expression">+ecdf_t_AB_IC_12+ecdf_t_FB_IC_12+ecdf_t_IB_IC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_714" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_714</field>
+      <field name="description">II.B. taxe 14%</field>
+      <field name="expression">+ecdf_t_AB_IC_14+ecdf_t_FB_IC_14+ecdf_t_IB_IC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_052" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_052</field>
+      <field name="description">II.B. taxe 15%</field>
+      <field name="expression">+ecdf_t_AB_IC_15+ecdf_t_FB_IC_15+ecdf_t_IB_IC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_712" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_712</field>
+      <field name="description">II.B. taxe 17%</field>
+      <field name="expression">+ecdf_t_AB_IC_17+ecdf_t_FB_IC_17+ecdf_t_IB_IC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_054" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_054</field>
+      <field name="description">II.B. taxe 3%</field>
+      <field name="expression">+ecdf_t_AB_IC_3+ecdf_t_FB_IC_3+ecdf_t_IB_IC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_053" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_053</field>
+      <field name="description">II.B. taxe 6%</field>
+      <field name="expression">+ecdf_t_AB_IC_6+ecdf_t_FB_IC_6+ecdf_t_IB_IC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_716" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_716</field>
+      <field name="description">II.B. taxe 8%</field>
+      <field name="expression">+ecdf_t_AB_IC_8+ecdf_t_FB_IC_8+ecdf_t_IB_IC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_069" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_069</field>
+      <field name="description">II.D.1. taxe 12%</field>
+      <field name="expression">+ecdf_t_AB_EC_12+ecdf_t_FB_EC_12+ecdf_t_IB_EC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_724" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_724</field>
+      <field name="description">II.D.1. taxe 14%</field>
+      <field name="expression">+ecdf_t_AB_EC_14+ecdf_t_FB_EC_14+ecdf_t_IB_EC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_066" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_066</field>
+      <field name="description">II.D.1. taxe 15%</field>
+      <field name="expression">+ecdf_t_AB_EC_15+ecdf_t_FB_EC_15+ecdf_t_IB_EC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_722" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_722</field>
+      <field name="description">II.D.1. taxe 17%</field>
+      <field name="expression">+ecdf_t_AB_EC_17+ecdf_t_FB_EC_17+ecdf_t_IB_EC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_068" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_068</field>
+      <field name="description">II.D.1. taxe 3%</field>
+      <field name="expression">+ecdf_t_AB_EC_3+ecdf_t_FB_EC_3+ecdf_t_IB_EC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_067" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_067</field>
+      <field name="description">II.D.1. taxe 6%</field>
+      <field name="expression">+ecdf_t_AB_EC_6+ecdf_t_FB_EC_6+ecdf_t_IB_EC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_726" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_726</field>
+      <field name="description">II.D.1. taxe 8%</field>
+      <field name="expression">+ecdf_t_AB_EC_8+ecdf_t_FB_EC_8+ecdf_t_IB_EC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_074" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_074</field>
+      <field name="description">II.D.2.. taxe 12%</field>
+      <field name="expression">+ecdf_t_AB_ECP_12+ecdf_t_FB_ECP_12+ecdf_t_IB_ECP_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_734" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_734</field>
+      <field name="description">II.D.2.. taxe 14%</field>
+      <field name="expression">+ecdf_t_AB_ECP_14+ecdf_t_FB_ECP_14+ecdf_t_IB_ECP_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_071" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_071</field>
+      <field name="description">II.D.2.. taxe 15%</field>
+      <field name="expression">+ecdf_t_AB_ECP_15+ecdf_t_FB_ECP_15+ecdf_t_IB_ECP_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_732" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_732</field>
+      <field name="description">II.D.2.. taxe 17%</field>
+      <field name="expression">+ecdf_t_AB_ECP_17+ecdf_t_FB_ECP_17+ecdf_t_IB_ECP_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2930</field>
+    </record>
+    <record id="mis_report_vat_ecdf_073" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_073</field>
+      <field name="description">II.D.2.. taxe 3%</field>
+      <field name="expression">+ecdf_t_AB_ECP_3+ecdf_t_FB_ECP_3+ecdf_t_IB_ECP_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2940</field>
+    </record>
+    <record id="mis_report_vat_ecdf_072" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_072</field>
+      <field name="description">II.D.2.. taxe 6%</field>
+      <field name="expression">+ecdf_t_AB_ECP_6+ecdf_t_FB_ECP_6+ecdf_t_IB_ECP_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2950</field>
+    </record>
+    <record id="mis_report_vat_ecdf_736" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_736</field>
+      <field name="description">II.D.2.. taxe 8%</field>
+      <field name="expression">+ecdf_t_AB_ECP_8+ecdf_t_FB_ECP_8+ecdf_t_IB_ECP_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2960</field>
+    </record>
+    <record id="mis_report_vat_ecdf_407" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_407</field>
+      <field name="description">II.D. Importations de biens – taxe</field>
+      <field name="expression">+ecdf_066+ecdf_067+ecdf_068+ecdf_069+ecdf_071+ecdf_072+ecdf_073+ecdf_074+ecdf_722+ecdf_724+ecdf_726+ecdf_732+ecdf_734+ecdf_736</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2970</field>
+    </record>
+    <record id="mis_report_vat_ecdf_462" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_462</field>
+      <field name="description">II.E.1.a) taxe</field>
+      <field name="expression">+ecdf_428+ecdf_430+ecdf_432+ecdf_434+ecdf_742+ecdf_744+ecdf_746</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2980</field>
+    </record>
+    <record id="mis_report_vat_ecdf_434" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_434</field>
+      <field name="description">II.E.1.a) taxe 12%</field>
+      <field name="expression">+ecdf_t_AP_IC_12+ecdf_t_FP_IC_12+ecdf_t_IP_IC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">2990</field>
+    </record>
+    <record id="mis_report_vat_ecdf_744" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_744</field>
+      <field name="description">II.E.1.a) taxe 14%</field>
+      <field name="expression">+ecdf_t_AP_IC_14+ecdf_t_FP_IC_14+ecdf_t_IP_IC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3000</field>
+    </record>
+    <record id="mis_report_vat_ecdf_428" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_428</field>
+      <field name="description">II.E.1.a) taxe 15%</field>
+      <field name="expression">+ecdf_t_AP_IC_15+ecdf_t_FP_IC_15+ecdf_t_IP_IC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3010</field>
+    </record>
+    <record id="mis_report_vat_ecdf_742" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_742</field>
+      <field name="description">II.E.1.a) taxe 17%</field>
+      <field name="expression">+ecdf_t_AP_IC_17+ecdf_t_FP_IC_17+ecdf_t_IP_IC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3020</field>
+    </record>
+    <record id="mis_report_vat_ecdf_432" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_432</field>
+      <field name="description">II.E.1.a) taxe 3%</field>
+      <field name="expression">+ecdf_t_AP_IC_3+ecdf_t_FP_IC_3+ecdf_t_IP_IC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3030</field>
+    </record>
+    <record id="mis_report_vat_ecdf_430" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_430</field>
+      <field name="description">II.E.1.a) taxe 6%</field>
+      <field name="expression">+ecdf_t_AP_IC_6+ecdf_t_FP_IC_6+ecdf_t_IP_IC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3040</field>
+    </record>
+    <record id="mis_report_vat_ecdf_746" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_746</field>
+      <field name="description">II.E.1.a) taxe 8%</field>
+      <field name="expression">+ecdf_t_AP_IC_8+ecdf_t_FP_IC_8+ecdf_t_IP_IC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3050</field>
+    </record>
+    <record id="mis_report_vat_ecdf_464" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_464</field>
+      <field name="description">II.E.2. taxe</field>
+      <field name="expression">+ecdf_438+ecdf_440+ecdf_442+ecdf_444+ecdf_752+ecdf_754+ecdf_756</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3060</field>
+    </record>
+    <record id="mis_report_vat_ecdf_444" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_444</field>
+      <field name="description">II.E.2. taxe 12%</field>
+      <field name="expression">+ecdf_t_AP_EC_12+ecdf_t_FP_EC_12+ecdf_t_IP_EC_12</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3070</field>
+    </record>
+    <record id="mis_report_vat_ecdf_754" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_754</field>
+      <field name="description">II.E.2. taxe 14%</field>
+      <field name="expression">+ecdf_t_AP_EC_14+ecdf_t_FP_EC_14+ecdf_t_IP_EC_14</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3080</field>
+    </record>
+    <record id="mis_report_vat_ecdf_438" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_438</field>
+      <field name="description">II.E.2. taxe 15%</field>
+      <field name="expression">+ecdf_t_AP_EC_15+ecdf_t_FP_EC_15+ecdf_t_IP_EC_15</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3090</field>
+    </record>
+    <record id="mis_report_vat_ecdf_752" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_752</field>
+      <field name="description">II.E.2. taxe 17%</field>
+      <field name="expression">+ecdf_t_AP_EC_17+ecdf_t_FP_EC_17+ecdf_t_IP_EC_17</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_442" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_442</field>
+      <field name="description">II.E.2. taxe 3%</field>
+      <field name="expression">+ecdf_t_AP_EC_3+ecdf_t_FP_EC_3+ecdf_t_IP_EC_3</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_440" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_440</field>
+      <field name="description">II.E.2. taxe 6%</field>
+      <field name="expression">+ecdf_t_AP_EC_6+ecdf_t_FP_EC_6+ecdf_t_IP_EC_6</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_756" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_756</field>
+      <field name="description">II.E.2. taxe 8%</field>
+      <field name="expression">+ecdf_t_AP_EC_8+ecdf_t_FP_EC_8+ecdf_t_IP_EC_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_766" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_766</field>
+      <field name="description">II.E.3. taxe</field>
+      <field name="expression">+ecdf_762+ecdf_421</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3131</field>
+    </record>
+    <record id="mis_report_vat_ext_762" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_762</field>
+      <field name="description">II.E.3. taxe 17%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3132</field>
+    </record>
+    <record id="mis_report_vat_ext_421" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_421</field>
+      <field name="description">II.E.3. taxe 15%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3133</field>
+    </record>
+    <record id="mis_report_vat_ecdf_410" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_410</field>
+      <field name="description">II.E. Prestations de services à déclarer par le preneur redevable de la taxe – taxe</field>
+      <field name="expression">+ecdf_462+ecdf_464+ecdf_766</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_768" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_768</field>
+      <field name="description">II.F. Livraisons de biens à déclarer par l'acquéreur redevable de la taxe – taxe</field>
+      <field name="expression">+ecdf_764+ecdf_223</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3141</field>
+    </record>
+    <record id="mis_report_vat_ext_764" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_764</field>
+      <field name="description">II.F. taxe 8%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3142</field>
+    </record>
+    <record id="mis_report_vat_ext_223" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_223</field>
+      <field name="description">II.F. taxe 6%</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3143</field>
+    </record>
+    <record id="mis_report_vat_ext_227" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_227</field>
+      <field name="description">II.G. Régime particulier suspensif: régularisation (art.60bis, par.5 et 8)</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3144</field>
+     </record>
+    <record id="mis_report_vat_ecdf_076" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_076</field>
+      <field name="description">II.H. Total de la taxe en aval</field>
+      <field name="expression">+ecdf_046+ecdf_056+ecdf_407+ecdf_410+ecdf_768+ecdf_227</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_458" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_458</field>
+      <field name="description">III.A.1. Achats de biens et de services à l'intérieur du pays (art.48/1/a)</field>
+      <field name="expression">+ecdf_t_AB_PA_12+ecdf_t_AB_PA_14+ecdf_t_AB_PA_15+ecdf_t_AB_PA_17+ecdf_t_AB_PA_3+ecdf_t_AB_PA_6+ecdf_t_AB_PA_8+ecdf_t_AP_PA_12+ecdf_t_AP_PA_14+ecdf_t_AP_PA_15+ecdf_t_AP_PA_17+ecdf_t_AP_PA_3+ecdf_t_AP_PA_6+ecdf_t_AP_PA_8+ecdf_t_FB_PA_12+ecdf_t_FB_PA_14+ecdf_t_FB_PA_15+ecdf_t_FB_PA_17+ecdf_t_FB_PA_3+ecdf_t_FB_PA_6+ecdf_t_FB_PA_8+ecdf_t_FP_PA_12+ecdf_t_FP_PA_14+ecdf_t_FP_PA_15+ecdf_t_FP_PA_17+ecdf_t_FP_PA_3+ecdf_t_FP_PA_6+ecdf_t_FP_PA_8+ecdf_t_IB_PA_12+ecdf_t_IB_PA_14+ecdf_t_IB_PA_15+ecdf_t_IB_PA_17+ecdf_t_IB_PA_3+ecdf_t_IB_PA_6+ecdf_t_IB_PA_8+ecdf_t_IP_PA_12+ecdf_t_IP_PA_14+ecdf_t_IP_PA_15+ecdf_t_IP_PA_17+ecdf_t_IP_PA_3+ecdf_t_IP_PA_6+ecdf_t_IP_PA_8</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_459" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_459</field>
+      <field name="description">III.A.2. Acquisitions intracommunautaires de biens (art.48/1/b)</field>
+      <field name="expression">+ecdf_t_AB_IC_12_n+ecdf_t_AB_IC_14_n+ecdf_t_AB_IC_15_n+ecdf_t_AB_IC_17_n+ecdf_t_AB_IC_3_n+ecdf_t_AB_IC_6_n+ecdf_t_AB_IC_8_n+ecdf_t_FB_IC_12_n+ecdf_t_FB_IC_14_n+ecdf_t_FB_IC_15_n+ecdf_t_FB_IC_17_n+ecdf_t_FB_IC_3_n+ecdf_t_FB_IC_6_n+ecdf_t_FB_IC_8_n+ecdf_t_IB_IC_12_n+ecdf_t_IB_IC_14_n+ecdf_t_IB_IC_15_n+ecdf_t_IB_IC_17_n+ecdf_t_IB_IC_3_n+ecdf_t_IB_IC_6_n+ecdf_t_IB_IC_8_n</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_460" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_460</field>
+      <field name="description">III.A.3. Importations de biens (taxe déclarée ou payée) (art.48/1/c)</field>
+      <field name="expression">+ecdf_t_AB_EC_12_n+ecdf_t_AB_EC_14_n+ecdf_t_AB_EC_15_n+ecdf_t_AB_EC_17_n+ecdf_t_AB_EC_3_n+ecdf_t_AB_EC_6_n+ecdf_t_AB_EC_8_n+ecdf_t_AB_ECP_12_n+ecdf_t_AB_ECP_14_n+ecdf_t_AB_ECP_15_n+ecdf_t_AB_ECP_17_n+ecdf_t_AB_ECP_3_n+ecdf_t_AB_ECP_6_n+ecdf_t_AB_ECP_8_n+ecdf_t_FB_EC_12_n+ecdf_t_FB_EC_14_n+ecdf_t_FB_EC_15_n+ecdf_t_FB_EC_17_n+ecdf_t_FB_EC_3_n+ecdf_t_FB_EC_6_n+ecdf_t_FB_EC_8_n+ecdf_t_FB_ECP_12_n+ecdf_t_FB_ECP_14_n+ecdf_t_FB_ECP_15_n+ecdf_t_FB_ECP_17_n+ecdf_t_FB_ECP_3_n+ecdf_t_FB_ECP_6_n+ecdf_t_FB_ECP_8_n+ecdf_t_IB_EC_12_n+ecdf_t_IB_EC_14_n+ecdf_t_IB_EC_15_n+ecdf_t_IB_EC_17_n+ecdf_t_IB_EC_3_n+ecdf_t_IB_EC_6_n+ecdf_t_IB_EC_8_n+ecdf_t_IB_ECP_12_n+ecdf_t_IB_ECP_14_n+ecdf_t_IB_ECP_15_n+ecdf_t_IB_ECP_17_n+ecdf_t_IB_ECP_3_n+ecdf_t_IB_ECP_6_n+ecdf_t_IB_ECP_8_n</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3180</field>
+    </record>
+    <record id="mis_report_vat_ext_090" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_090</field>
+      <field name="description">III.A.4. Affectations de biens (art.48/1/d)</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_461" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_461</field>
+      <field name="description">III.A.5. Taxe déclarée comme débiteur (voir points II.E et F)</field>
+      <field name="expression">+ecdf_t_AP_EC_12_n+ecdf_t_AP_EC_14_n+ecdf_t_AP_EC_15_n+ecdf_t_AP_EC_17_n+ecdf_t_AP_EC_3_n+ecdf_t_AP_EC_6_n+ecdf_t_AP_EC_8_n+ecdf_t_AP_IC_12_n+ecdf_t_AP_IC_14_n+ecdf_t_AP_IC_15_n+ecdf_t_AP_IC_17_n+ecdf_t_AP_IC_3_n+ecdf_t_AP_IC_6_n+ecdf_t_AP_IC_8_n+ecdf_t_FP_EC_12_n+ecdf_t_FP_EC_14_n+ecdf_t_FP_EC_15_n+ecdf_t_FP_EC_17_n+ecdf_t_FP_EC_3_n+ecdf_t_FP_EC_6_n+ecdf_t_FP_EC_8_n+ecdf_t_FP_IC_12_n+ecdf_t_FP_IC_14_n+ecdf_t_FP_IC_15_n+ecdf_t_FP_IC_17_n+ecdf_t_FP_IC_3_n+ecdf_t_FP_IC_6_n+ecdf_t_FP_IC_8_n+ecdf_t_IP_EC_12_n+ecdf_t_IP_EC_14_n+ecdf_t_IP_EC_15_n+ecdf_t_IP_EC_17_n+ecdf_t_IP_EC_3_n+ecdf_t_IP_EC_6_n+ecdf_t_IP_EC_8_n+ecdf_t_IP_IC_12_n+ecdf_t_IP_IC_14_n+ecdf_t_IP_IC_15_n+ecdf_t_IP_IC_17_n+ecdf_t_IP_IC_3_n+ecdf_t_IP_IC_6_n+ecdf_t_IP_IC_8_n</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3200</field>
+    </record>
+    <record id="mis_report_vat_ext_092" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_092</field>
+      <field name="description">III.A.6. Taxe acquittée comme caution solidaire</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3210</field>
+    </record>
+    <record id="mis_report_vat_ext_228" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_228</field>
+      <field name="description">III.A.7. Taxe régularisée - régime particulier suspensif (art.60bis/9, al. 2)</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_093" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_093</field>
+      <field name="description">III.A. Total de la taxe en amont</field>
+      <field name="expression">+ecdf_090+ecdf_092+ecdf_228+ecdf_458+ecdf_459+ecdf_460+ecdf_461</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_097" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_097</field>
+      <field name="description">III.B. Total de la taxe en amont non déductible</field>
+      <field name="expression">ecdf_094+ecdf_095</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3231</field>
+    </record>
+    <record id="mis_report_vat_ext_094" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_094</field>
+      <field name="description">III.B.1. en rapport avec des opérations exonérées en vertu des art. 44 et 56quater</field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3232</field>
+    </record>
+    <record id="mis_report_vat_ext_095" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ext_095</field>
+      <field name="description">III.B.2. en application du prorata visé à l'article 50 </field>
+      <field name="expression">0</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3233</field>
+    </record>
+    <record id="mis_report_vat_ecdf_102" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_102</field>
+      <field name="description">III.C. Total de la taxe en amont déductible</field>
+      <field name="expression">+ecdf_093-ecdf_097</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_104" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_104</field>
+      <field name="description">IV.A. Total de la taxe en amont déductible</field>
+      <field name="expression">+ecdf_102</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_103" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_103</field>
+      <field name="description">IV.A. Total de la taxe en aval</field>
+      <field name="expression">+ecdf_076</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_105" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_105</field>
+      <field name="description">IV.C. Excédent</field>
+      <field name="expression">+ecdf_103-ecdf_104</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_12_n</field>
+      <field name="description">Taxe - Achat Biens 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_12</field>
+      <field name="description">Taxe - Achat Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3290</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_12_n</field>
+      <field name="description">Taxe - Achat Biens 12% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_12</field>
+      <field name="description">Taxe - Achat Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_12_n</field>
+      <field name="description">Taxe - Achat Biens 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_12</field>
+      <field name="description">Taxe - Achat Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_12</field>
+      <field name="description">Taxe - Achat Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_14_n</field>
+      <field name="description">Taxe - Achat Biens 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_14</field>
+      <field name="description">Taxe - Achat Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_14_n</field>
+      <field name="description">Taxe - Achat Biens 14% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_14</field>
+      <field name="description">Taxe - Achat Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_14_n</field>
+      <field name="description">Taxe - Achat Biens 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_14</field>
+      <field name="description">Taxe - Achat Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_14</field>
+      <field name="description">Taxe - Achat Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_15_n</field>
+      <field name="description">Taxe - Achat Biens 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_15</field>
+      <field name="description">Taxe - Achat Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_15_n</field>
+      <field name="description">Taxe - Achat Biens 15% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_15</field>
+      <field name="description">Taxe - Achat Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_15_n</field>
+      <field name="description">Taxe - Achat Biens 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_15</field>
+      <field name="description">Taxe - Achat Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_15</field>
+      <field name="description">Taxe - Achat Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_17_n</field>
+      <field name="description">Taxe - Achat Biens 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_17</field>
+      <field name="description">Taxe - Achat Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_17_n</field>
+      <field name="description">Taxe - Achat Biens 17% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_17</field>
+      <field name="description">Taxe - Achat Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_17_n</field>
+      <field name="description">Taxe - Achat Biens 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_17</field>
+      <field name="description">Taxe - Achat Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_17</field>
+      <field name="description">Taxe - Achat Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_3_n</field>
+      <field name="description">Taxe - Achat Biens 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_3</field>
+      <field name="description">Taxe - Achat Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_3_n</field>
+      <field name="description">Taxe - Achat Biens 3% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_3</field>
+      <field name="description">Taxe - Achat Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_3_n</field>
+      <field name="description">Taxe - Achat Biens 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_3</field>
+      <field name="description">Taxe - Achat Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_3</field>
+      <field name="description">Taxe - Achat Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_6_n</field>
+      <field name="description">Taxe - Achat Biens 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_6</field>
+      <field name="description">Taxe - Achat Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3640</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_6_n</field>
+      <field name="description">Taxe - Achat Biens 6% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3650</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_6</field>
+      <field name="description">Taxe - Achat Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_6_n</field>
+      <field name="description">Taxe - Achat Biens 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_6</field>
+      <field name="description">Taxe - Achat Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_6</field>
+      <field name="description">Taxe - Achat Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_8_n</field>
+      <field name="description">Taxe - Achat Biens 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_EC_8</field>
+      <field name="description">Taxe - Achat Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_8_n</field>
+      <field name="description">Taxe - Achat Biens 8% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_ECP_8</field>
+      <field name="description">Taxe - Achat Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_8_n</field>
+      <field name="description">Taxe - Achat Biens 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_IC_8</field>
+      <field name="description">Taxe - Achat Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AB_PA_8</field>
+      <field name="description">Taxe - Achat Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_12_n</field>
+      <field name="description">Taxe - Achat Prestations 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_12</field>
+      <field name="description">Taxe - Achat Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_12_n</field>
+      <field name="description">Taxe - Achat Prestations 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_12</field>
+      <field name="description">Taxe - Achat Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_12</field>
+      <field name="description">Taxe - Achat Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_14_n</field>
+      <field name="description">Taxe - Achat Prestations 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_14</field>
+      <field name="description">Taxe - Achat Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_14_n</field>
+      <field name="description">Taxe - Achat Prestations 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_14</field>
+      <field name="description">Taxe - Achat Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_14</field>
+      <field name="description">Taxe - Achat Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_15_n</field>
+      <field name="description">Taxe - Achat Prestations 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_15</field>
+      <field name="description">Taxe - Achat Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_15_n</field>
+      <field name="description">Taxe - Achat Prestations 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_15</field>
+      <field name="description">Taxe - Achat Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_15</field>
+      <field name="description">Taxe - Achat Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_17_n</field>
+      <field name="description">Taxe - Achat Prestations 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_17</field>
+      <field name="description">Taxe - Achat Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3930</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_17_n</field>
+      <field name="description">Taxe - Achat Prestations 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3940</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_17</field>
+      <field name="description">Taxe - Achat Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3950</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_17</field>
+      <field name="description">Taxe - Achat Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3960</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_3_n</field>
+      <field name="description">Taxe - Achat Prestations 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3970</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_3</field>
+      <field name="description">Taxe - Achat Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3980</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_3_n</field>
+      <field name="description">Taxe - Achat Prestations 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">3990</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_3</field>
+      <field name="description">Taxe - Achat Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4000</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_3</field>
+      <field name="description">Taxe - Achat Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4010</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_6_n</field>
+      <field name="description">Taxe - Achat Prestations 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4020</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_6</field>
+      <field name="description">Taxe - Achat Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4030</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_6_n</field>
+      <field name="description">Taxe - Achat Prestations 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4040</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_6</field>
+      <field name="description">Taxe - Achat Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4050</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_6</field>
+      <field name="description">Taxe - Achat Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4060</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_8_n</field>
+      <field name="description">Taxe - Achat Prestations 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4070</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_EC_8</field>
+      <field name="description">Taxe - Achat Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4080</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_8_n</field>
+      <field name="description">Taxe - Achat Prestations 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4090</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_IC_8</field>
+      <field name="description">Taxe - Achat Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_AP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_AP_PA_8</field>
+      <field name="description">Taxe - Achat Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_12_n</field>
+      <field name="description">Taxe - Frais Biens 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_12</field>
+      <field name="description">Taxe - Frais Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_12_n</field>
+      <field name="description">Taxe - Frais Biens 12% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_12</field>
+      <field name="description">Taxe - Frais Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_12_n</field>
+      <field name="description">Taxe - Frais Biens 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_12</field>
+      <field name="description">Taxe - Frais Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_12</field>
+      <field name="description">Taxe - Frais Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4180</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_14_n</field>
+      <field name="description">Taxe - Frais Biens 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_14</field>
+      <field name="description">Taxe - Frais Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4200</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_14_n</field>
+      <field name="description">Taxe - Frais Biens 14% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4210</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_14</field>
+      <field name="description">Taxe - Frais Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_14_n</field>
+      <field name="description">Taxe - Frais Biens 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_14</field>
+      <field name="description">Taxe - Frais Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_14</field>
+      <field name="description">Taxe - Frais Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_15_n</field>
+      <field name="description">Taxe - Frais Biens 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_15</field>
+      <field name="description">Taxe - Frais Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_15_n</field>
+      <field name="description">Taxe - Frais Biens 15% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_15</field>
+      <field name="description">Taxe - Frais Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4290</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_15_n</field>
+      <field name="description">Taxe - Frais Biens 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_15</field>
+      <field name="description">Taxe - Frais Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_15</field>
+      <field name="description">Taxe - Frais Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_17_n</field>
+      <field name="description">Taxe - Frais Biens 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_17</field>
+      <field name="description">Taxe - Frais Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_17_n</field>
+      <field name="description">Taxe - Frais Biens 17% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_17</field>
+      <field name="description">Taxe - Frais Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_17_n</field>
+      <field name="description">Taxe - Frais Biens 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_17</field>
+      <field name="description">Taxe - Frais Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_17</field>
+      <field name="description">Taxe - Frais Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_3_n</field>
+      <field name="description">Taxe - Frais Biens 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_3</field>
+      <field name="description">Taxe - Frais Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_3_n</field>
+      <field name="description">Taxe - Frais Biens 3% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_3</field>
+      <field name="description">Taxe - Frais Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_3_n</field>
+      <field name="description">Taxe - Frais Biens 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_3</field>
+      <field name="description">Taxe - Frais Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_3</field>
+      <field name="description">Taxe - Frais Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_6_n</field>
+      <field name="description">Taxe - Frais Biens 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_6</field>
+      <field name="description">Taxe - Frais Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_6_n</field>
+      <field name="description">Taxe - Frais Biens 6% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_6</field>
+      <field name="description">Taxe - Frais Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_6_n</field>
+      <field name="description">Taxe - Frais Biens 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_6</field>
+      <field name="description">Taxe - Frais Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_6</field>
+      <field name="description">Taxe - Frais Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_8_n</field>
+      <field name="description">Taxe - Frais Biens 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_EC_8</field>
+      <field name="description">Taxe - Frais Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_8_n</field>
+      <field name="description">Taxe - Frais Biens 8% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_ECP_8</field>
+      <field name="description">Taxe - Frais Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_8_n</field>
+      <field name="description">Taxe - Frais Biens 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_IC_8</field>
+      <field name="description">Taxe - Frais Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FB_PA_8</field>
+      <field name="description">Taxe - Frais Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_12_n</field>
+      <field name="description">Taxe - Frais Prestations 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_12</field>
+      <field name="description">Taxe - Frais Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_12_n</field>
+      <field name="description">Taxe - Frais Prestations 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_12</field>
+      <field name="description">Taxe - Frais Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4640</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_12</field>
+      <field name="description">Taxe - Frais Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4650</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_14_n</field>
+      <field name="description">Taxe - Frais Prestations 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_14</field>
+      <field name="description">Taxe - Frais Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_14_n</field>
+      <field name="description">Taxe - Frais Prestations 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_14</field>
+      <field name="description">Taxe - Frais Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_14</field>
+      <field name="description">Taxe - Frais Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_15_n</field>
+      <field name="description">Taxe - Frais Prestations 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_15</field>
+      <field name="description">Taxe - Frais Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_15_n</field>
+      <field name="description">Taxe - Frais Prestations 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_15</field>
+      <field name="description">Taxe - Frais Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_15</field>
+      <field name="description">Taxe - Frais Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_17_n</field>
+      <field name="description">Taxe - Frais Prestations 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_17</field>
+      <field name="description">Taxe - Frais Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_17_n</field>
+      <field name="description">Taxe - Frais Prestations 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_17</field>
+      <field name="description">Taxe - Frais Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_17</field>
+      <field name="description">Taxe - Frais Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_3_n</field>
+      <field name="description">Taxe - Frais Prestations 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_3</field>
+      <field name="description">Taxe - Frais Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_3_n</field>
+      <field name="description">Taxe - Frais Prestations 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_3</field>
+      <field name="description">Taxe - Frais Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_3</field>
+      <field name="description">Taxe - Frais Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_6_n</field>
+      <field name="description">Taxe - Frais Prestations 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_6</field>
+      <field name="description">Taxe - Frais Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_6_n</field>
+      <field name="description">Taxe - Frais Prestations 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_6</field>
+      <field name="description">Taxe - Frais Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_6</field>
+      <field name="description">Taxe - Frais Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_8_n</field>
+      <field name="description">Taxe - Frais Prestations 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_EC_8</field>
+      <field name="description">Taxe - Frais Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_8_n</field>
+      <field name="description">Taxe - Frais Prestations 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4930</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_IC_8</field>
+      <field name="description">Taxe - Frais Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4940</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_FP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_FP_PA_8</field>
+      <field name="description">Taxe - Frais Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4950</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_12_n</field>
+      <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4960</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_12</field>
+      <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4970</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_12_n</field>
+      <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4980</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_12</field>
+      <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">4990</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_12_n</field>
+      <field name="description">Taxe - Investissement Biens 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5000</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_12</field>
+      <field name="description">Taxe - Investissement Biens 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5010</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_12</field>
+      <field name="description">Taxe - Investissement Biens 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5020</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_14_n</field>
+      <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5030</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_14</field>
+      <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5040</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_14_n</field>
+      <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5050</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_14</field>
+      <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5060</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_14_n</field>
+      <field name="description">Taxe - Investissement Biens 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5070</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_14</field>
+      <field name="description">Taxe - Investissement Biens 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5080</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_14</field>
+      <field name="description">Taxe - Investissement Biens 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5090</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_15_n</field>
+      <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5100</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_15</field>
+      <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5110</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_15_n</field>
+      <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5120</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_15</field>
+      <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5130</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_15_n</field>
+      <field name="description">Taxe - Investissement Biens 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5140</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_15</field>
+      <field name="description">Taxe - Investissement Biens 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5150</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_15</field>
+      <field name="description">Taxe - Investissement Biens 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5160</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_17_n</field>
+      <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5170</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_17</field>
+      <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5180</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_17_n</field>
+      <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5190</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_17</field>
+      <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5200</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_17_n</field>
+      <field name="description">Taxe - Investissement Biens 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5210</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_17</field>
+      <field name="description">Taxe - Investissement Biens 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5220</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_17</field>
+      <field name="description">Taxe - Investissement Biens 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5230</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_3_n</field>
+      <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5240</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_3</field>
+      <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5250</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_3_n</field>
+      <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5260</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_3</field>
+      <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5270</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_3_n</field>
+      <field name="description">Taxe - Investissement Biens 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5280</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_3</field>
+      <field name="description">Taxe - Investissement Biens 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5290</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_3</field>
+      <field name="description">Taxe - Investissement Biens 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5300</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_6_n</field>
+      <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5310</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_6</field>
+      <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5320</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_6_n</field>
+      <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5330</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_6</field>
+      <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5340</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_6_n</field>
+      <field name="description">Taxe - Investissement Biens 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5350</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_6</field>
+      <field name="description">Taxe - Investissement Biens 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5360</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_6</field>
+      <field name="description">Taxe - Investissement Biens 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5370</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_8_n</field>
+      <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5380</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_EC_8</field>
+      <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5390</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_8_n</field>
+      <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire fin privées (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5400</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_ECP_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_ECP_8</field>
+      <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire fin privées (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5410</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_8_n</field>
+      <field name="description">Taxe - Investissement Biens 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5420</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_IC_8</field>
+      <field name="description">Taxe - Investissement Biens 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5430</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IB_PA_8</field>
+      <field name="description">Taxe - Investissement Biens 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5440</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_12_n</field>
+      <field name="description">Taxe - Investissement Prestations 12% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5450</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_12</field>
+      <field name="description">Taxe - Investissement Prestations 12% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5460</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_12_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_12_n</field>
+      <field name="description">Taxe - Investissement Prestations 12% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-12-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5470</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_12</field>
+      <field name="description">Taxe - Investissement Prestations 12% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-12-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5480</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_12</field>
+      <field name="description">Taxe - Investissement Prestations 12% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5490</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_14_n</field>
+      <field name="description">Taxe - Investissement Prestations 14% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5500</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_14</field>
+      <field name="description">Taxe - Investissement Prestations 14% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5510</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_14_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_14_n</field>
+      <field name="description">Taxe - Investissement Prestations 14% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-14-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5520</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_14</field>
+      <field name="description">Taxe - Investissement Prestations 14% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-14-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5530</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_14</field>
+      <field name="description">Taxe - Investissement Prestations 14% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5540</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_15_n</field>
+      <field name="description">Taxe - Investissement Prestations 15% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5550</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_15</field>
+      <field name="description">Taxe - Investissement Prestations 15% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5560</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_15_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_15_n</field>
+      <field name="description">Taxe - Investissement Prestations 15% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-15-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5570</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_15</field>
+      <field name="description">Taxe - Investissement Prestations 15% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-15-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5580</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_15</field>
+      <field name="description">Taxe - Investissement Prestations 15% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5590</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_17_n</field>
+      <field name="description">Taxe - Investissement Prestations 17% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5600</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_17</field>
+      <field name="description">Taxe - Investissement Prestations 17% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5610</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_17_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_17_n</field>
+      <field name="description">Taxe - Investissement Prestations 17% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-17-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5620</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_17</field>
+      <field name="description">Taxe - Investissement Prestations 17% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-17-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5630</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_17</field>
+      <field name="description">Taxe - Investissement Prestations 17% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5640</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_3_n</field>
+      <field name="description">Taxe - Investissement Prestations 3% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5650</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_3</field>
+      <field name="description">Taxe - Investissement Prestations 3% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5660</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_3_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_3_n</field>
+      <field name="description">Taxe - Investissement Prestations 3% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-3-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5670</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_3</field>
+      <field name="description">Taxe - Investissement Prestations 3% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-3-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5680</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_3</field>
+      <field name="description">Taxe - Investissement Prestations 3% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5690</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_6_n</field>
+      <field name="description">Taxe - Investissement Prestations 6% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5700</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_6</field>
+      <field name="description">Taxe - Investissement Prestations 6% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5710</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_6_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_6_n</field>
+      <field name="description">Taxe - Investissement Prestations 6% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-6-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5720</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_6</field>
+      <field name="description">Taxe - Investissement Prestations 6% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-6-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5730</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_6</field>
+      <field name="description">Taxe - Investissement Prestations 6% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5740</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_8_n</field>
+      <field name="description">Taxe - Investissement Prestations 8% - Extracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5750</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_EC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_EC_8</field>
+      <field name="description">Taxe - Investissement Prestations 8% - Extracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5760</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_8_n" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_8_n</field>
+      <field name="description">Taxe - Investissement Prestations 8% - Intracommunautaire (-)</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-8-n')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5770</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_IC_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_IC_8</field>
+      <field name="description">Taxe - Investissement Prestations 8% - Intracommunautaire (+)</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-8-p')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5780</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_IP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_IP_PA_8</field>
+      <field name="description">Taxe - Investissement Prestations 8% - Pays</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5790</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_12</field>
+      <field name="description">Taxe - Vente Biens 12% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5800</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_14</field>
+      <field name="description">Taxe - Vente Biens 14% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5810</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_15</field>
+      <field name="description">Taxe - Vente Biens 15% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5820</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_17</field>
+      <field name="description">Taxe - Vente Biens 17% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5830</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_3</field>
+      <field name="description">Taxe - Vente Biens 3% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5840</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_6</field>
+      <field name="description">Taxe - Vente Biens 6% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5850</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VB_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VB_PA_8</field>
+      <field name="description">Taxe - Vente Biens 8% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5860</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_12" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_12</field>
+      <field name="description">Taxe - Vente Prestations 12% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-12')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5870</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_14" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_14</field>
+      <field name="description">Taxe - Vente Prestations 14% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-14')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5880</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_15" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_15</field>
+      <field name="description">Taxe - Vente Prestations 15% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-15')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5890</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_17" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_17</field>
+      <field name="description">Taxe - Vente Prestations 17% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-17')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5900</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_3" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_3</field>
+      <field name="description">Taxe - Vente Prestations 3% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-3')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5910</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_6" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_6</field>
+      <field name="description">Taxe - Vente Prestations 6% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-6')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5920</field>
+    </record>
+    <record id="mis_report_vat_ecdf_t_VP_PA_8" model="mis.report.kpi">
+      <field ref="mis_report_vat" name="report_id"/>
+      <field name="name">ecdf_t_VP_PA_8</field>
+      <field name="description">Taxe - Vente Prestations 8% - Pays</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-8')]</field>
+
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+
+      <field name="sequence">5930</field>
+    </record>
+
+</odoo>

--- a/l10n_lu_mis_reports/data/mis_report_vat.xml
+++ b/l10n_lu_mis_reports/data/mis_report_vat.xml
@@ -10,7 +10,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_12</field>
       <field name="description">Base - Achat Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -21,7 +21,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_12</field>
       <field name="description">Base - Achat Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -32,7 +32,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_12</field>
       <field name="description">Base - Achat Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -43,7 +43,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_14</field>
       <field name="description">Base - Achat Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -54,7 +54,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_14</field>
       <field name="description">Base - Achat Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -65,7 +65,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_14</field>
       <field name="description">Base - Achat Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -76,7 +76,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_15</field>
       <field name="description">Base - Achat Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -87,7 +87,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_15</field>
       <field name="description">Base - Achat Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -98,7 +98,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_15</field>
       <field name="description">Base - Achat Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -109,7 +109,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_17</field>
       <field name="description">Base - Achat Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -120,7 +120,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_17</field>
       <field name="description">Base - Achat Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -131,7 +131,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_17</field>
       <field name="description">Base - Achat Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -142,7 +142,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_3</field>
       <field name="description">Base - Achat Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -153,7 +153,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_3</field>
       <field name="description">Base - Achat Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -164,7 +164,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_3</field>
       <field name="description">Base - Achat Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -175,7 +175,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_6</field>
       <field name="description">Base - Achat Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -186,7 +186,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_6</field>
       <field name="description">Base - Achat Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -197,7 +197,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_6</field>
       <field name="description">Base - Achat Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -208,7 +208,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_8</field>
       <field name="description">Base - Achat Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -219,7 +219,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_8</field>
       <field name="description">Base - Achat Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -230,7 +230,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_8</field>
       <field name="description">Base - Achat Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -241,7 +241,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_EC_0</field>
       <field name="description">Base - Achat Biens Exonéré - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -252,7 +252,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_ECP_0</field>
       <field name="description">Base - Achat Biens Exonéré - Extracommunautaire fin privées</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-ECP-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-ECP-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -263,7 +263,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_IC_0</field>
       <field name="description">Base - Achat Biens Exonéré - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -274,7 +274,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_12</field>
       <field name="description">Base - Achat Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -285,7 +285,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_12</field>
       <field name="description">Base - Achat Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -296,7 +296,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_14</field>
       <field name="description">Base - Achat Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -307,7 +307,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_14</field>
       <field name="description">Base - Achat Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -318,7 +318,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_15</field>
       <field name="description">Base - Achat Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -329,7 +329,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_15</field>
       <field name="description">Base - Achat Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -340,7 +340,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_17</field>
       <field name="description">Base - Achat Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -351,7 +351,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_17</field>
       <field name="description">Base - Achat Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -362,7 +362,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_3</field>
       <field name="description">Base - Achat Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -373,7 +373,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_3</field>
       <field name="description">Base - Achat Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -384,7 +384,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_6</field>
       <field name="description">Base - Achat Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -395,7 +395,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_6</field>
       <field name="description">Base - Achat Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -406,7 +406,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_8</field>
       <field name="description">Base - Achat Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -417,7 +417,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_8</field>
       <field name="description">Base - Achat Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -428,7 +428,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_EC_0</field>
       <field name="description">Base - Achat Prestations Exonérées - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -439,7 +439,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_IC_0</field>
       <field name="description">Base - Achat Prestations Exonérées - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -450,7 +450,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_12</field>
       <field name="description">Base - Frais Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -461,7 +461,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_12</field>
       <field name="description">Base - Frais Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -472,7 +472,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_12</field>
       <field name="description">Base - Frais Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -483,7 +483,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_14</field>
       <field name="description">Base - Frais Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -494,7 +494,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_14</field>
       <field name="description">Base - Frais Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -505,7 +505,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_14</field>
       <field name="description">Base - Frais Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -516,7 +516,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_15</field>
       <field name="description">Base - Frais Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -527,7 +527,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_15</field>
       <field name="description">Base - Frais Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -538,7 +538,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_15</field>
       <field name="description">Base - Frais Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -549,7 +549,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_17</field>
       <field name="description">Base - Frais Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -560,7 +560,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_17</field>
       <field name="description">Base - Frais Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -571,7 +571,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_17</field>
       <field name="description">Base - Frais Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -582,7 +582,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_3</field>
       <field name="description">Base - Frais Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -593,7 +593,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_3</field>
       <field name="description">Base - Frais Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -604,7 +604,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_3</field>
       <field name="description">Base - Frais Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -615,7 +615,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_6</field>
       <field name="description">Base - Frais Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -626,7 +626,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_6</field>
       <field name="description">Base - Frais Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -637,7 +637,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_6</field>
       <field name="description">Base - Frais Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -648,7 +648,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_8</field>
       <field name="description">Base - Frais Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -659,7 +659,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_8</field>
       <field name="description">Base - Frais Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -670,7 +670,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_8</field>
       <field name="description">Base - Frais Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -681,7 +681,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_EC_0</field>
       <field name="description">Base - Frais Biens Exonéré - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -692,7 +692,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_ECP_0</field>
       <field name="description">Base - Frais Biens Exonéré - Extracommunautaire fin privées</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-ECP-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-ECP-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -703,7 +703,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_IC_0</field>
       <field name="description">Base - Frais Biens Exonéré - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -714,7 +714,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_12</field>
       <field name="description">Base - Frais Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -725,7 +725,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_12</field>
       <field name="description">Base - Frais Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -736,7 +736,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_14</field>
       <field name="description">Base - Frais Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -747,7 +747,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_14</field>
       <field name="description">Base - Frais Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -758,7 +758,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_15</field>
       <field name="description">Base - Frais Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -769,7 +769,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_15</field>
       <field name="description">Base - Frais Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -780,7 +780,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_17</field>
       <field name="description">Base - Frais Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -791,7 +791,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_17</field>
       <field name="description">Base - Frais Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -802,7 +802,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_3</field>
       <field name="description">Base - Frais Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -813,7 +813,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_3</field>
       <field name="description">Base - Frais Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -824,7 +824,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_6</field>
       <field name="description">Base - Frais Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -835,7 +835,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_6</field>
       <field name="description">Base - Frais Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -846,7 +846,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_8</field>
       <field name="description">Base - Frais Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -857,7 +857,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_8</field>
       <field name="description">Base - Frais Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -868,7 +868,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_EC_0</field>
       <field name="description">Base - Frais Prestations Exonérées - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -879,7 +879,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_IC_0</field>
       <field name="description">Base - Frais Prestations Exonérées - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -890,7 +890,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_12</field>
       <field name="description">Base - Investissement Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -901,7 +901,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_12</field>
       <field name="description">Base - Investissement Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -912,7 +912,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_12</field>
       <field name="description">Base - Investissement Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -923,7 +923,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_14</field>
       <field name="description">Base - Investissement Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -934,7 +934,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_14</field>
       <field name="description">Base - Investissement Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -945,7 +945,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_14</field>
       <field name="description">Base - Investissement Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -956,7 +956,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_15</field>
       <field name="description">Base - Investissement Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -967,7 +967,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_15</field>
       <field name="description">Base - Investissement Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -978,7 +978,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_15</field>
       <field name="description">Base - Investissement Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -989,7 +989,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_17</field>
       <field name="description">Base - Investissement Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1000,7 +1000,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_17</field>
       <field name="description">Base - Investissement Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1011,7 +1011,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_17</field>
       <field name="description">Base - Investissement Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1022,7 +1022,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_3</field>
       <field name="description">Base - Investissement Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1033,7 +1033,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_3</field>
       <field name="description">Base - Investissement Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1044,7 +1044,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_3</field>
       <field name="description">Base - Investissement Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1055,7 +1055,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_6</field>
       <field name="description">Base - Investissement Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1066,7 +1066,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_6</field>
       <field name="description">Base - Investissement Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1077,7 +1077,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_6</field>
       <field name="description">Base - Investissement Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1088,7 +1088,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_8</field>
       <field name="description">Base - Investissement Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1099,7 +1099,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_8</field>
       <field name="description">Base - Investissement Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1110,7 +1110,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_8</field>
       <field name="description">Base - Investissement Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1121,7 +1121,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_EC_0</field>
       <field name="description">Base - Investissement Biens Exonéré - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1132,7 +1132,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_ECP_0</field>
       <field name="description">Base - Investissement Biens Exonéré - Extracommunautaire fin privées</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-ECP-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-ECP-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1143,7 +1143,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_IC_0</field>
       <field name="description">Base - Investissement Biens Exonéré - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1154,7 +1154,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_12</field>
       <field name="description">Base - Investissement Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1165,7 +1165,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_12</field>
       <field name="description">Base - Investissement Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1176,7 +1176,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_14</field>
       <field name="description">Base - Investissement Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1187,7 +1187,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_14</field>
       <field name="description">Base - Investissement Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1198,7 +1198,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_15</field>
       <field name="description">Base - Investissement Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1209,7 +1209,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_15</field>
       <field name="description">Base - Investissement Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1220,7 +1220,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_17</field>
       <field name="description">Base - Investissement Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1231,7 +1231,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_17</field>
       <field name="description">Base - Investissement Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1242,7 +1242,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_3</field>
       <field name="description">Base - Investissement Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1253,7 +1253,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_3</field>
       <field name="description">Base - Investissement Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1264,7 +1264,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_6</field>
       <field name="description">Base - Investissement Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1275,7 +1275,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_6</field>
       <field name="description">Base - Investissement Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1286,7 +1286,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_8</field>
       <field name="description">Base - Investissement Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1297,7 +1297,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_8</field>
       <field name="description">Base - Investissement Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1308,7 +1308,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_EC_0</field>
       <field name="description">Base - Investissement Prestations Exonérées - Extracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-EC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1319,7 +1319,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_IC_0</field>
       <field name="description">Base - Investissement Prestations Exonérées - Intracommunautaire</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-IC-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1902,7 +1902,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_V_ART_43_60b</field>
       <field name="description">Base - Vente - Autres Exonérations (Article 43 et 60 bis)</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'V-ART-43_60b')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'V-ART-43_60b')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1913,7 +1913,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_V_ART_44_56q</field>
       <field name="description">Base - Vente - Autres Exonérations (Article 44 et 56 quarter)</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'V-ART-44_56q')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'V-ART-44_56q')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1924,7 +1924,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_0</field>
       <field name="description">Base - Vente Biens 0% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1935,7 +1935,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_12</field>
       <field name="description">Base - Vente Biens 12% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-12')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1946,7 +1946,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_14</field>
       <field name="description">Base - Vente Biens 14% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-14')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1957,7 +1957,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_15</field>
       <field name="description">Base - Vente Biens 15% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-15')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1968,7 +1968,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_17</field>
       <field name="description">Base - Vente Biens 17% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-17')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1979,7 +1979,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_3</field>
       <field name="description">Base - Vente Biens 3% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-3')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1990,7 +1990,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_6</field>
       <field name="description">Base - Vente Biens 6% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-6')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2001,7 +2001,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_8</field>
       <field name="description">Base - Vente Biens 8% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-8')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2012,7 +2012,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_EC_0</field>
       <field name="description">Base - Vente Biens - Extracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-EC-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2023,7 +2023,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_IC_0</field>
       <field name="description">Base - Vente Biens - Intracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-IC-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2034,7 +2034,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_EC_Tab</field>
       <field name="description">Base - Vente Biens Tabacs - Extracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-EC-Tab')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-EC-Tab')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2045,7 +2045,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_IC_Tab</field>
       <field name="description">Base - Vente Biens Tabacs - Intracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-IC-Tab')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-IC-Tab')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2056,7 +2056,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_PA_Tab</field>
       <field name="description">Base - Vente Biens Tabacs - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-PA-Tab')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-PA-Tab')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2067,7 +2067,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VB_TR_0</field>
       <field name="description">Base - Vente Biens – Triangulaire Intracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VB-TR-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VB-TR-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2078,7 +2078,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_0</field>
       <field name="description">Base - Vente Prestations 0% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2089,7 +2089,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_12</field>
       <field name="description">Base - Vente Prestations 12% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-12')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2100,7 +2100,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_14</field>
       <field name="description">Base - Vente Prestations 14% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-14')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2111,7 +2111,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_15</field>
       <field name="description">Base - Vente Prestations 15% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-15')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2122,7 +2122,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_17</field>
       <field name="description">Base - Vente Prestations 17% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-17')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2133,7 +2133,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_3</field>
       <field name="description">Base - Vente Prestations 3% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-3')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2144,7 +2144,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_6</field>
       <field name="description">Base - Vente Prestations 6% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-6')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2155,7 +2155,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_PA_8</field>
       <field name="description">Base - Vente Prestations 8% - Pays</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-8')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2166,7 +2166,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_EC_0</field>
       <field name="description">Base - Vente Prestations - Extracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-EC-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-EC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2177,7 +2177,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_IC_0</field>
       <field name="description">Base - Vente Prestations - Intracommunautaire</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-IC-0')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-IC-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2188,7 +2188,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_VP_IC_EX</field>
       <field name="description">Base - Vente Prestations - Intracommunautaire exonérées dans l'état membre</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-IC-EX')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-IC-EX')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2540,7 +2540,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_0</field>
       <field name="description">Base - Achat Biens 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2551,7 +2551,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_12</field>
       <field name="description">Base - Achat Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2562,7 +2562,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_14</field>
       <field name="description">Base - Achat Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2573,7 +2573,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_15</field>
       <field name="description">Base - Achat Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2584,7 +2584,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_17</field>
       <field name="description">Base - Achat Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2595,7 +2595,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_3</field>
       <field name="description">Base - Achat Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2606,7 +2606,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_6</field>
       <field name="description">Base - Achat Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2617,7 +2617,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AB_PA_8</field>
       <field name="description">Base - Achat Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AB-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2628,7 +2628,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_0</field>
       <field name="description">Base - Achat Prestations 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2639,7 +2639,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_12</field>
       <field name="description">Base - Achat Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2650,7 +2650,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_14</field>
       <field name="description">Base - Achat Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2661,7 +2661,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_15</field>
       <field name="description">Base - Achat Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2672,7 +2672,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_17</field>
       <field name="description">Base - Achat Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2683,7 +2683,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_3</field>
       <field name="description">Base - Achat Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2694,7 +2694,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_6</field>
       <field name="description">Base - Achat Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2705,7 +2705,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_AP_PA_8</field>
       <field name="description">Base - Achat Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'AP-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'AP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2716,7 +2716,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_0</field>
       <field name="description">Base - Frais Biens 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2727,7 +2727,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_12</field>
       <field name="description">Base - Frais Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2738,7 +2738,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_14</field>
       <field name="description">Base - Frais Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2749,7 +2749,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_15</field>
       <field name="description">Base - Frais Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2760,7 +2760,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_17</field>
       <field name="description">Base - Frais Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2771,7 +2771,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_3</field>
       <field name="description">Base - Frais Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2782,7 +2782,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_6</field>
       <field name="description">Base - Frais Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2793,7 +2793,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FB_PA_8</field>
       <field name="description">Base - Frais Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FB-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2804,7 +2804,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_0</field>
       <field name="description">Base - Frais Prestations 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2815,7 +2815,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_12</field>
       <field name="description">Base - Frais Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2826,7 +2826,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_14</field>
       <field name="description">Base - Frais Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2837,7 +2837,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_15</field>
       <field name="description">Base - Frais Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2848,7 +2848,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_17</field>
       <field name="description">Base - Frais Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2859,7 +2859,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_3</field>
       <field name="description">Base - Frais Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2870,7 +2870,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_6</field>
       <field name="description">Base - Frais Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2881,7 +2881,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_FP_PA_8</field>
       <field name="description">Base - Frais Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'FP-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'FP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2892,7 +2892,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_0</field>
       <field name="description">Base - Investissement Biens 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2903,7 +2903,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_12</field>
       <field name="description">Base - Investissement Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2914,7 +2914,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_14</field>
       <field name="description">Base - Investissement Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2925,7 +2925,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_15</field>
       <field name="description">Base - Investissement Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2936,7 +2936,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_17</field>
       <field name="description">Base - Investissement Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2947,7 +2947,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_3</field>
       <field name="description">Base - Investissement Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2958,7 +2958,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_6</field>
       <field name="description">Base - Investissement Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2969,7 +2969,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IB_PA_8</field>
       <field name="description">Base - Investissement Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IB-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2980,7 +2980,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_0</field>
       <field name="description">Base - Investissement Prestations 0% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-0')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-0')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2991,7 +2991,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_12</field>
       <field name="description">Base - Investissement Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-12')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3002,7 +3002,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_14</field>
       <field name="description">Base - Investissement Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-14')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3013,7 +3013,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_15</field>
       <field name="description">Base - Investissement Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-15')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3024,7 +3024,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_17</field>
       <field name="description">Base - Investissement Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-17')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3035,7 +3035,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_3</field>
       <field name="description">Base - Investissement Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-3')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3046,7 +3046,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_6</field>
       <field name="description">Base - Investissement Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-6')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3057,7 +3057,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_b_IP_PA_8</field>
       <field name="description">Base - Investissement Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', '=', 'IP-PA-8')]</field>
+      <field name="expression">bal[][('tax_ids.description', '=', 'IP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3068,7 +3068,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">b_SANS</field>
       <field name="description">Base - Sans Taxe</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'VP-PA-SANS')]</field>
+      <field name="expression">-bal[][('tax_ids.description', '=', 'VP-PA-SANS')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3893,7 +3893,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_12_n</field>
       <field name="description">Taxe - Achat Biens 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3904,7 +3904,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_12</field>
       <field name="description">Taxe - Achat Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3915,7 +3915,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_12_n</field>
       <field name="description">Taxe - Achat Biens 12% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3926,7 +3926,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_12</field>
       <field name="description">Taxe - Achat Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3937,7 +3937,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_12_n</field>
       <field name="description">Taxe - Achat Biens 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3948,7 +3948,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_12</field>
       <field name="description">Taxe - Achat Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3959,7 +3959,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_12</field>
       <field name="description">Taxe - Achat Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3970,7 +3970,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_14_n</field>
       <field name="description">Taxe - Achat Biens 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3981,7 +3981,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_14</field>
       <field name="description">Taxe - Achat Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3992,7 +3992,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_14_n</field>
       <field name="description">Taxe - Achat Biens 14% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4003,7 +4003,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_14</field>
       <field name="description">Taxe - Achat Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4014,7 +4014,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_14_n</field>
       <field name="description">Taxe - Achat Biens 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4025,7 +4025,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_14</field>
       <field name="description">Taxe - Achat Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4036,7 +4036,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_14</field>
       <field name="description">Taxe - Achat Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4047,7 +4047,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_15_n</field>
       <field name="description">Taxe - Achat Biens 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4058,7 +4058,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_15</field>
       <field name="description">Taxe - Achat Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4069,7 +4069,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_15_n</field>
       <field name="description">Taxe - Achat Biens 15% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4080,7 +4080,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_15</field>
       <field name="description">Taxe - Achat Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4091,7 +4091,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_15_n</field>
       <field name="description">Taxe - Achat Biens 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4102,7 +4102,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_15</field>
       <field name="description">Taxe - Achat Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4113,7 +4113,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_15</field>
       <field name="description">Taxe - Achat Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4124,7 +4124,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_17_n</field>
       <field name="description">Taxe - Achat Biens 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4135,7 +4135,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_17</field>
       <field name="description">Taxe - Achat Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4146,7 +4146,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_17_n</field>
       <field name="description">Taxe - Achat Biens 17% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4157,7 +4157,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_17</field>
       <field name="description">Taxe - Achat Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4168,7 +4168,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_17_n</field>
       <field name="description">Taxe - Achat Biens 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4179,7 +4179,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_17</field>
       <field name="description">Taxe - Achat Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4190,7 +4190,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_17</field>
       <field name="description">Taxe - Achat Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4201,7 +4201,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_3_n</field>
       <field name="description">Taxe - Achat Biens 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4212,7 +4212,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_3</field>
       <field name="description">Taxe - Achat Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4223,7 +4223,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_3_n</field>
       <field name="description">Taxe - Achat Biens 3% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4234,7 +4234,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_3</field>
       <field name="description">Taxe - Achat Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4245,7 +4245,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_3_n</field>
       <field name="description">Taxe - Achat Biens 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4256,7 +4256,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_3</field>
       <field name="description">Taxe - Achat Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4267,7 +4267,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_3</field>
       <field name="description">Taxe - Achat Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4278,7 +4278,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_6_n</field>
       <field name="description">Taxe - Achat Biens 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4289,7 +4289,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_6</field>
       <field name="description">Taxe - Achat Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4300,7 +4300,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_6_n</field>
       <field name="description">Taxe - Achat Biens 6% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4311,7 +4311,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_6</field>
       <field name="description">Taxe - Achat Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4322,7 +4322,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_6_n</field>
       <field name="description">Taxe - Achat Biens 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4333,7 +4333,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_6</field>
       <field name="description">Taxe - Achat Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4344,7 +4344,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_6</field>
       <field name="description">Taxe - Achat Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4355,7 +4355,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_8_n</field>
       <field name="description">Taxe - Achat Biens 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4366,7 +4366,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_EC_8</field>
       <field name="description">Taxe - Achat Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4377,7 +4377,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_8_n</field>
       <field name="description">Taxe - Achat Biens 8% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-ECP-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4388,7 +4388,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_ECP_8</field>
       <field name="description">Taxe - Achat Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-ECP-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-ECP-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4399,7 +4399,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_8_n</field>
       <field name="description">Taxe - Achat Biens 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AB-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4410,7 +4410,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_IC_8</field>
       <field name="description">Taxe - Achat Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4421,7 +4421,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AB_PA_8</field>
       <field name="description">Taxe - Achat Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AB-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4432,7 +4432,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_12_n</field>
       <field name="description">Taxe - Achat Prestations 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4443,7 +4443,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_12</field>
       <field name="description">Taxe - Achat Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4454,7 +4454,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_12_n</field>
       <field name="description">Taxe - Achat Prestations 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4465,7 +4465,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_12</field>
       <field name="description">Taxe - Achat Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4476,7 +4476,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_12</field>
       <field name="description">Taxe - Achat Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4487,7 +4487,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_14_n</field>
       <field name="description">Taxe - Achat Prestations 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4498,7 +4498,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_14</field>
       <field name="description">Taxe - Achat Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4509,7 +4509,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_14_n</field>
       <field name="description">Taxe - Achat Prestations 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4520,7 +4520,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_14</field>
       <field name="description">Taxe - Achat Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4531,7 +4531,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_14</field>
       <field name="description">Taxe - Achat Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4542,7 +4542,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_15_n</field>
       <field name="description">Taxe - Achat Prestations 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4553,7 +4553,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_15</field>
       <field name="description">Taxe - Achat Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4564,7 +4564,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_15_n</field>
       <field name="description">Taxe - Achat Prestations 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4575,7 +4575,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_15</field>
       <field name="description">Taxe - Achat Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4586,7 +4586,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_15</field>
       <field name="description">Taxe - Achat Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4597,7 +4597,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_17_n</field>
       <field name="description">Taxe - Achat Prestations 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4608,7 +4608,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_17</field>
       <field name="description">Taxe - Achat Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4619,7 +4619,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_17_n</field>
       <field name="description">Taxe - Achat Prestations 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4630,7 +4630,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_17</field>
       <field name="description">Taxe - Achat Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4641,7 +4641,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_17</field>
       <field name="description">Taxe - Achat Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4652,7 +4652,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_3_n</field>
       <field name="description">Taxe - Achat Prestations 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4663,7 +4663,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_3</field>
       <field name="description">Taxe - Achat Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4674,7 +4674,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_3_n</field>
       <field name="description">Taxe - Achat Prestations 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4685,7 +4685,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_3</field>
       <field name="description">Taxe - Achat Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4696,7 +4696,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_3</field>
       <field name="description">Taxe - Achat Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4707,7 +4707,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_6_n</field>
       <field name="description">Taxe - Achat Prestations 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4718,7 +4718,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_6</field>
       <field name="description">Taxe - Achat Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4729,7 +4729,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_6_n</field>
       <field name="description">Taxe - Achat Prestations 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4740,7 +4740,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_6</field>
       <field name="description">Taxe - Achat Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4751,7 +4751,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_6</field>
       <field name="description">Taxe - Achat Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4762,7 +4762,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_8_n</field>
       <field name="description">Taxe - Achat Prestations 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4773,7 +4773,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_EC_8</field>
       <field name="description">Taxe - Achat Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4784,7 +4784,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_8_n</field>
       <field name="description">Taxe - Achat Prestations 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'AP-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4795,7 +4795,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_IC_8</field>
       <field name="description">Taxe - Achat Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4806,7 +4806,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_AP_PA_8</field>
       <field name="description">Taxe - Achat Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'AP-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'AP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4817,7 +4817,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_12_n</field>
       <field name="description">Taxe - Frais Biens 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4828,7 +4828,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_12</field>
       <field name="description">Taxe - Frais Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4839,7 +4839,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_12_n</field>
       <field name="description">Taxe - Frais Biens 12% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4850,7 +4850,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_12</field>
       <field name="description">Taxe - Frais Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4861,7 +4861,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_12_n</field>
       <field name="description">Taxe - Frais Biens 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4872,7 +4872,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_12</field>
       <field name="description">Taxe - Frais Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4883,7 +4883,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_12</field>
       <field name="description">Taxe - Frais Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4894,7 +4894,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_14_n</field>
       <field name="description">Taxe - Frais Biens 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4905,7 +4905,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_14</field>
       <field name="description">Taxe - Frais Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4916,7 +4916,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_14_n</field>
       <field name="description">Taxe - Frais Biens 14% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4927,7 +4927,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_14</field>
       <field name="description">Taxe - Frais Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4938,7 +4938,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_14_n</field>
       <field name="description">Taxe - Frais Biens 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4949,7 +4949,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_14</field>
       <field name="description">Taxe - Frais Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4960,7 +4960,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_14</field>
       <field name="description">Taxe - Frais Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4971,7 +4971,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_15_n</field>
       <field name="description">Taxe - Frais Biens 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4982,7 +4982,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_15</field>
       <field name="description">Taxe - Frais Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -4993,7 +4993,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_15_n</field>
       <field name="description">Taxe - Frais Biens 15% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5004,7 +5004,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_15</field>
       <field name="description">Taxe - Frais Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5015,7 +5015,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_15_n</field>
       <field name="description">Taxe - Frais Biens 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5026,7 +5026,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_15</field>
       <field name="description">Taxe - Frais Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5037,7 +5037,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_15</field>
       <field name="description">Taxe - Frais Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5048,7 +5048,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_17_n</field>
       <field name="description">Taxe - Frais Biens 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5059,7 +5059,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_17</field>
       <field name="description">Taxe - Frais Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5070,7 +5070,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_17_n</field>
       <field name="description">Taxe - Frais Biens 17% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5081,7 +5081,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_17</field>
       <field name="description">Taxe - Frais Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5092,7 +5092,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_17_n</field>
       <field name="description">Taxe - Frais Biens 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5103,7 +5103,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_17</field>
       <field name="description">Taxe - Frais Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5114,7 +5114,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_17</field>
       <field name="description">Taxe - Frais Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5125,7 +5125,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_3_n</field>
       <field name="description">Taxe - Frais Biens 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5136,7 +5136,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_3</field>
       <field name="description">Taxe - Frais Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5147,7 +5147,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_3_n</field>
       <field name="description">Taxe - Frais Biens 3% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5158,7 +5158,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_3</field>
       <field name="description">Taxe - Frais Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5169,7 +5169,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_3_n</field>
       <field name="description">Taxe - Frais Biens 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5180,7 +5180,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_3</field>
       <field name="description">Taxe - Frais Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5191,7 +5191,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_3</field>
       <field name="description">Taxe - Frais Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5202,7 +5202,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_6_n</field>
       <field name="description">Taxe - Frais Biens 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5213,7 +5213,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_6</field>
       <field name="description">Taxe - Frais Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5224,7 +5224,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_6_n</field>
       <field name="description">Taxe - Frais Biens 6% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5235,7 +5235,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_6</field>
       <field name="description">Taxe - Frais Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5246,7 +5246,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_6_n</field>
       <field name="description">Taxe - Frais Biens 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5257,7 +5257,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_6</field>
       <field name="description">Taxe - Frais Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5268,7 +5268,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_6</field>
       <field name="description">Taxe - Frais Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5279,7 +5279,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_8_n</field>
       <field name="description">Taxe - Frais Biens 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5290,7 +5290,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_EC_8</field>
       <field name="description">Taxe - Frais Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5301,7 +5301,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_8_n</field>
       <field name="description">Taxe - Frais Biens 8% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-ECP-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5312,7 +5312,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_ECP_8</field>
       <field name="description">Taxe - Frais Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-ECP-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-ECP-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5323,7 +5323,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_8_n</field>
       <field name="description">Taxe - Frais Biens 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FB-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5334,7 +5334,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_IC_8</field>
       <field name="description">Taxe - Frais Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5345,7 +5345,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FB_PA_8</field>
       <field name="description">Taxe - Frais Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FB-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5356,7 +5356,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_12_n</field>
       <field name="description">Taxe - Frais Prestations 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5367,7 +5367,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_12</field>
       <field name="description">Taxe - Frais Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5378,7 +5378,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_12_n</field>
       <field name="description">Taxe - Frais Prestations 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5389,7 +5389,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_12</field>
       <field name="description">Taxe - Frais Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5400,7 +5400,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_12</field>
       <field name="description">Taxe - Frais Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5411,7 +5411,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_14_n</field>
       <field name="description">Taxe - Frais Prestations 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5422,7 +5422,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_14</field>
       <field name="description">Taxe - Frais Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5433,7 +5433,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_14_n</field>
       <field name="description">Taxe - Frais Prestations 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5444,7 +5444,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_14</field>
       <field name="description">Taxe - Frais Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5455,7 +5455,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_14</field>
       <field name="description">Taxe - Frais Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5466,7 +5466,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_15_n</field>
       <field name="description">Taxe - Frais Prestations 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5477,7 +5477,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_15</field>
       <field name="description">Taxe - Frais Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5488,7 +5488,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_15_n</field>
       <field name="description">Taxe - Frais Prestations 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5499,7 +5499,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_15</field>
       <field name="description">Taxe - Frais Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5510,7 +5510,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_15</field>
       <field name="description">Taxe - Frais Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5521,7 +5521,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_17_n</field>
       <field name="description">Taxe - Frais Prestations 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5532,7 +5532,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_17</field>
       <field name="description">Taxe - Frais Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5543,7 +5543,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_17_n</field>
       <field name="description">Taxe - Frais Prestations 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5554,7 +5554,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_17</field>
       <field name="description">Taxe - Frais Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5565,7 +5565,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_17</field>
       <field name="description">Taxe - Frais Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5576,7 +5576,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_3_n</field>
       <field name="description">Taxe - Frais Prestations 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5587,7 +5587,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_3</field>
       <field name="description">Taxe - Frais Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5598,7 +5598,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_3_n</field>
       <field name="description">Taxe - Frais Prestations 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5609,7 +5609,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_3</field>
       <field name="description">Taxe - Frais Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5620,7 +5620,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_3</field>
       <field name="description">Taxe - Frais Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5631,7 +5631,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_6_n</field>
       <field name="description">Taxe - Frais Prestations 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5642,7 +5642,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_6</field>
       <field name="description">Taxe - Frais Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5653,7 +5653,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_6_n</field>
       <field name="description">Taxe - Frais Prestations 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5664,7 +5664,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_6</field>
       <field name="description">Taxe - Frais Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5675,7 +5675,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_6</field>
       <field name="description">Taxe - Frais Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5686,7 +5686,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_8_n</field>
       <field name="description">Taxe - Frais Prestations 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5697,7 +5697,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_EC_8</field>
       <field name="description">Taxe - Frais Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5708,7 +5708,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_8_n</field>
       <field name="description">Taxe - Frais Prestations 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'FP-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5719,7 +5719,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_IC_8</field>
       <field name="description">Taxe - Frais Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5730,7 +5730,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_FP_PA_8</field>
       <field name="description">Taxe - Frais Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'FP-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'FP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5741,7 +5741,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_12_n</field>
       <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5752,7 +5752,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_12</field>
       <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5763,7 +5763,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_12_n</field>
       <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5774,7 +5774,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_12</field>
       <field name="description">Taxe - Investissement Biens 12% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5785,7 +5785,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_12_n</field>
       <field name="description">Taxe - Investissement Biens 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5796,7 +5796,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_12</field>
       <field name="description">Taxe - Investissement Biens 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5807,7 +5807,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_12</field>
       <field name="description">Taxe - Investissement Biens 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5818,7 +5818,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_14_n</field>
       <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5829,7 +5829,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_14</field>
       <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5840,7 +5840,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_14_n</field>
       <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5851,7 +5851,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_14</field>
       <field name="description">Taxe - Investissement Biens 14% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5862,7 +5862,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_14_n</field>
       <field name="description">Taxe - Investissement Biens 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5873,7 +5873,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_14</field>
       <field name="description">Taxe - Investissement Biens 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5884,7 +5884,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_14</field>
       <field name="description">Taxe - Investissement Biens 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5895,7 +5895,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_15_n</field>
       <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5906,7 +5906,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_15</field>
       <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5917,7 +5917,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_15_n</field>
       <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5928,7 +5928,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_15</field>
       <field name="description">Taxe - Investissement Biens 15% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5939,7 +5939,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_15_n</field>
       <field name="description">Taxe - Investissement Biens 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5950,7 +5950,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_15</field>
       <field name="description">Taxe - Investissement Biens 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5961,7 +5961,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_15</field>
       <field name="description">Taxe - Investissement Biens 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5972,7 +5972,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_17_n</field>
       <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5983,7 +5983,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_17</field>
       <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -5994,7 +5994,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_17_n</field>
       <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6005,7 +6005,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_17</field>
       <field name="description">Taxe - Investissement Biens 17% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6016,7 +6016,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_17_n</field>
       <field name="description">Taxe - Investissement Biens 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6027,7 +6027,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_17</field>
       <field name="description">Taxe - Investissement Biens 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6038,7 +6038,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_17</field>
       <field name="description">Taxe - Investissement Biens 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6049,7 +6049,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_3_n</field>
       <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6060,7 +6060,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_3</field>
       <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6071,7 +6071,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_3_n</field>
       <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6082,7 +6082,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_3</field>
       <field name="description">Taxe - Investissement Biens 3% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6093,7 +6093,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_3_n</field>
       <field name="description">Taxe - Investissement Biens 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6104,7 +6104,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_3</field>
       <field name="description">Taxe - Investissement Biens 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6115,7 +6115,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_3</field>
       <field name="description">Taxe - Investissement Biens 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6126,7 +6126,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_6_n</field>
       <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6137,7 +6137,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_6</field>
       <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6148,7 +6148,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_6_n</field>
       <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6159,7 +6159,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_6</field>
       <field name="description">Taxe - Investissement Biens 6% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6170,7 +6170,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_6_n</field>
       <field name="description">Taxe - Investissement Biens 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6181,7 +6181,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_6</field>
       <field name="description">Taxe - Investissement Biens 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6192,7 +6192,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_6</field>
       <field name="description">Taxe - Investissement Biens 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6203,7 +6203,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_8_n</field>
       <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6214,7 +6214,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_EC_8</field>
       <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6225,7 +6225,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_8_n</field>
       <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire fin privées (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-ECP-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6236,7 +6236,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_ECP_8</field>
       <field name="description">Taxe - Investissement Biens 8% - Extracommunautaire fin privées (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-ECP-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-ECP-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6247,7 +6247,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_8_n</field>
       <field name="description">Taxe - Investissement Biens 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IB-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6258,7 +6258,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_IC_8</field>
       <field name="description">Taxe - Investissement Biens 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6269,7 +6269,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IB_PA_8</field>
       <field name="description">Taxe - Investissement Biens 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IB-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6280,7 +6280,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_12_n</field>
       <field name="description">Taxe - Investissement Prestations 12% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6291,7 +6291,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_12</field>
       <field name="description">Taxe - Investissement Prestations 12% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6302,7 +6302,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_12_n</field>
       <field name="description">Taxe - Investissement Prestations 12% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-12-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-12-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6313,7 +6313,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_12</field>
       <field name="description">Taxe - Investissement Prestations 12% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-12-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-12-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6324,7 +6324,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_12</field>
       <field name="description">Taxe - Investissement Prestations 12% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-12')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6335,7 +6335,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_14_n</field>
       <field name="description">Taxe - Investissement Prestations 14% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6346,7 +6346,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_14</field>
       <field name="description">Taxe - Investissement Prestations 14% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6357,7 +6357,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_14_n</field>
       <field name="description">Taxe - Investissement Prestations 14% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-14-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-14-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6368,7 +6368,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_14</field>
       <field name="description">Taxe - Investissement Prestations 14% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-14-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-14-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6379,7 +6379,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_14</field>
       <field name="description">Taxe - Investissement Prestations 14% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-14')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6390,7 +6390,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_15_n</field>
       <field name="description">Taxe - Investissement Prestations 15% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6401,7 +6401,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_15</field>
       <field name="description">Taxe - Investissement Prestations 15% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6412,7 +6412,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_15_n</field>
       <field name="description">Taxe - Investissement Prestations 15% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-15-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-15-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6423,7 +6423,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_15</field>
       <field name="description">Taxe - Investissement Prestations 15% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-15-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-15-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6434,7 +6434,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_15</field>
       <field name="description">Taxe - Investissement Prestations 15% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-15')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6445,7 +6445,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_17_n</field>
       <field name="description">Taxe - Investissement Prestations 17% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6456,7 +6456,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_17</field>
       <field name="description">Taxe - Investissement Prestations 17% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6467,7 +6467,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_17_n</field>
       <field name="description">Taxe - Investissement Prestations 17% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-17-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-17-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6478,7 +6478,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_17</field>
       <field name="description">Taxe - Investissement Prestations 17% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-17-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-17-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6489,7 +6489,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_17</field>
       <field name="description">Taxe - Investissement Prestations 17% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-17')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6500,7 +6500,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_3_n</field>
       <field name="description">Taxe - Investissement Prestations 3% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6511,7 +6511,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_3</field>
       <field name="description">Taxe - Investissement Prestations 3% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6522,7 +6522,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_3_n</field>
       <field name="description">Taxe - Investissement Prestations 3% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-3-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-3-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6533,7 +6533,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_3</field>
       <field name="description">Taxe - Investissement Prestations 3% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-3-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-3-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6544,7 +6544,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_3</field>
       <field name="description">Taxe - Investissement Prestations 3% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-3')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6555,7 +6555,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_6_n</field>
       <field name="description">Taxe - Investissement Prestations 6% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6566,7 +6566,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_6</field>
       <field name="description">Taxe - Investissement Prestations 6% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6577,7 +6577,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_6_n</field>
       <field name="description">Taxe - Investissement Prestations 6% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-6-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-6-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6588,7 +6588,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_6</field>
       <field name="description">Taxe - Investissement Prestations 6% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-6-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-6-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6599,7 +6599,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_6</field>
       <field name="description">Taxe - Investissement Prestations 6% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-6')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6610,7 +6610,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_8_n</field>
       <field name="description">Taxe - Investissement Prestations 8% - Extracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-EC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6621,7 +6621,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_EC_8</field>
       <field name="description">Taxe - Investissement Prestations 8% - Extracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-EC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-EC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6632,7 +6632,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_8_n</field>
       <field name="description">Taxe - Investissement Prestations 8% - Intracommunautaire (-)</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-8-n')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'IP-IC-8-n')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6643,7 +6643,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_IC_8</field>
       <field name="description">Taxe - Investissement Prestations 8% - Intracommunautaire (+)</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-IC-8-p')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-IC-8-p')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6654,7 +6654,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_IP_PA_8</field>
       <field name="description">Taxe - Investissement Prestations 8% - Pays</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', '=', 'IP-PA-8')]</field>
+      <field name="expression">bal[][('tax_line_id.description', '=', 'IP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6665,7 +6665,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_12</field>
       <field name="description">Taxe - Vente Biens 12% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-12')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6676,7 +6676,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_14</field>
       <field name="description">Taxe - Vente Biens 14% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-14')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6687,7 +6687,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_15</field>
       <field name="description">Taxe - Vente Biens 15% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-15')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6698,7 +6698,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_17</field>
       <field name="description">Taxe - Vente Biens 17% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-17')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6709,7 +6709,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_3</field>
       <field name="description">Taxe - Vente Biens 3% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-3')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6720,7 +6720,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_6</field>
       <field name="description">Taxe - Vente Biens 6% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-6')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6731,7 +6731,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VB_PA_8</field>
       <field name="description">Taxe - Vente Biens 8% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VB-PA-8')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VB-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6742,7 +6742,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_12</field>
       <field name="description">Taxe - Vente Prestations 12% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-12')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-12')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6753,7 +6753,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_14</field>
       <field name="description">Taxe - Vente Prestations 14% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-14')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-14')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6764,7 +6764,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_15</field>
       <field name="description">Taxe - Vente Prestations 15% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-15')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-15')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6775,7 +6775,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_17</field>
       <field name="description">Taxe - Vente Prestations 17% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-17')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-17')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6786,7 +6786,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_3</field>
       <field name="description">Taxe - Vente Prestations 3% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-3')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-3')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6797,7 +6797,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_6</field>
       <field name="description">Taxe - Vente Prestations 6% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-6')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-6')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -6808,7 +6808,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_t_VP_PA_8</field>
       <field name="description">Taxe - Vente Prestations 8% - Pays</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', '=', 'VP-PA-8')]</field>
+      <field name="expression">-bal[][('tax_line_id.description', '=', 'VP-PA-8')]</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>

--- a/l10n_lu_mis_reports/data/mis_report_vat.xml
+++ b/l10n_lu_mis_reports/data/mis_report_vat.xml
@@ -4,7 +4,7 @@
 
 <odoo>
     <record id="mis_report_vat" model="mis.report">
-      <field name="name">VAT 2015</field>
+      <field name="name">Déclaration TVA Mensuelle (modèle 2015)</field>
     </record>
     <record id="mis_report_vat_ecdf_b_AB_EC_12" model="mis.report.kpi">
       <field ref="mis_report_vat" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_vat.xml
+++ b/l10n_lu_mis_reports/data/mis_report_vat.xml
@@ -1825,7 +1825,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_765</field>
       <field name="description">II.E.3. base</field>
-      <field name="expression">ecdf_761+ecdf_420</field>
+      <field name="expression">ext_761+ext_420</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -1869,7 +1869,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_767</field>
       <field name="description">II.F. Livraisons de biens à déclarer par l'acquéreur redevable de la taxe – base</field>
-      <field name="expression">+ecdf_763+ecdf_222</field>
+      <field name="expression">+ext_763+ext_222</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2199,7 +2199,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_012</field>
       <field name="description">I.A. Chiffre d'affaires global</field>
-      <field name="expression">+ecdf_454+ecdf_455+ecdf_456</field>
+      <field name="expression">+ext_454+ext_455+ext_456</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2364,7 +2364,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_021</field>
       <field name="description">I.B. Exonérations et montants déductibles</field>
-      <field name="expression">+ecdf_014+ecdf_015+ecdf_016+ecdf_017+ecdf_018+ecdf_019+ecdf_226+ecdf_419+ecdf_423+ecdf_424+ecdf_457</field>
+      <field name="expression">+ecdf_014+ecdf_015+ecdf_016+ecdf_017+ecdf_018+ecdf_019+ext_226+ext_419+ecdf_423+ecdf_424+ecdf_457</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -2382,9 +2382,9 @@
 
       <field name="sequence">2070</field>
     </record>
-    <record id="mis_report_vat_ecdf_403" model="mis.report.kpi">
+    <record id="mis_report_vat_ext_403" model="mis.report.kpi">
       <field ref="mis_report_vat" name="report_id"/>
-      <field name="name">ecdf_403</field>
+      <field name="name">ext_403</field>
       <field name="description">II.A 0%</field>
       <field name="expression">0</field>
 
@@ -2395,7 +2395,7 @@
     </record>
     <record id="mis_report_vat_ext_418" model="mis.report.kpi">
       <field ref="mis_report_vat" name="report_id"/>
-      <field name="name">ecdf_418</field>
+      <field name="name">ext_418</field>
       <field name="description">II.A _%</field>
       <field name="expression">0</field>
 
@@ -2406,7 +2406,7 @@
     </record>
     <record id="mis_report_vat_ext_453" model="mis.report.kpi">
       <field ref="mis_report_vat" name="report_id"/>
-      <field name="name">ecdf_453</field>
+      <field name="name">ext_453</field>
       <field name="description">II.A _%</field>
       <field name="expression">0</field>
 
@@ -2529,7 +2529,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_037</field>
       <field name="description">II.A. Ventilation du chiffre d'affaires imposable – base</field>
-      <field name="expression">+ecdf_029+ecdf_030+ecdf_031+ecdf_032+ecdf_033+ecdf_701+ecdf_703+ecdf_705+ecdf_416+ecdf_451</field>
+      <field name="expression">+ecdf_029+ecdf_030+ecdf_031+ecdf_032+ecdf_033+ecdf_701+ecdf_703+ecdf_705+ext_416+ext_451</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3189,7 +3189,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_046</field>
       <field name="description">II.A. Ventilation du chiffre d'affaires imposable – taxe</field>
-      <field name="expression">+ecdf_038+ecdf_039+ecdf_040+ecdf_041+ecdf_042+ecdf_702+ecdf_704+ecdf_706+ecdf_417+ecdf_452</field>
+      <field name="expression">+ecdf_038+ecdf_039+ecdf_040+ecdf_041+ext_042+ecdf_702+ecdf_704+ecdf_706+ext_417+ext_452</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3629,7 +3629,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_766</field>
       <field name="description">II.E.3. taxe</field>
-      <field name="expression">+ecdf_762+ecdf_421</field>
+      <field name="expression">+ext_762+ext_421</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3673,7 +3673,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_768</field>
       <field name="description">II.F. Livraisons de biens à déclarer par l'acquéreur redevable de la taxe – taxe</field>
-      <field name="expression">+ecdf_764+ecdf_223</field>
+      <field name="expression">+ext_764+ext_223</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3717,7 +3717,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_076</field>
       <field name="description">II.H. Total de la taxe en aval</field>
-      <field name="expression">+ecdf_046+ecdf_056+ecdf_407+ecdf_410+ecdf_768+ecdf_227</field>
+      <field name="expression">+ecdf_046+ecdf_056+ecdf_407+ecdf_410+ecdf_768+ext_227</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3805,7 +3805,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_093</field>
       <field name="description">III.A. Total de la taxe en amont</field>
-      <field name="expression">+ecdf_090+ecdf_092+ecdf_228+ecdf_458+ecdf_459+ecdf_460+ecdf_461</field>
+      <field name="expression">+ext_090+ext_092+ext_228+ecdf_458+ecdf_459+ecdf_460+ecdf_461</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>
@@ -3816,7 +3816,7 @@
       <field ref="mis_report_vat" name="report_id"/>
       <field name="name">ecdf_097</field>
       <field name="description">III.B. Total de la taxe en amont non déductible</field>
-      <field name="expression">ecdf_094+ecdf_095</field>
+      <field name="expression">ext_094+ext_095</field>
 
       <field name="type">num</field>
       <field name="compare_method">pct</field>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 account-financial-reporting
+mis-builder


### PR DESCRIPTION
- [x] Add the mis builder template for Luxemburg VAT declaration
- [x] Use tax description instead of tax tag name
- [x] Fix manual kpi's (`ext_`) referencing
- [x] Rename report
- [x] Add missing external dependency in the repository

TODO
- [ ] revert https://github.com/OCA/l10n-luxemburg/pull/24/commits/c06790d271e819e9c4ab86c89763f771bf8648c1
- [ ] move to l10n_lu_mis_reports_tax
- [ ] add some style
- [ ] make som KPI invisible (eg the intracom +/- values)