### PR TITLE
[8.0][ADD] l10n_lu_mis_reports: ecdf 2016-2017 templates

### DIFF
--- a/l10n_lu_ecdf/README.rst
+++ b/l10n_lu_ecdf/README.rst
@@ -1,0 +1,65 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+======================
+Luxemburg eCDF reports
+======================
+
+Luxemburg annual reports in eCDF XML format.
+
+This modules provides a wizard to export the annual reports
+(P&L, Balance Sheet, Chart of Accounts) in XML format, ready to 
+upload on the eCDF platform.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to Accounting > Reporting > Legal Reports > Luxembourg
+#. Click on eCDF annual reports
+#. Fill the wizard and download the XML file.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/123/8.0
+
+Known issues / Roadmap
+======================
+
+* Only the full format is supported.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/l10n-luxemburg/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Thomas Binsfeld <thomas.binsfeld@acsone.eu>
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_lu_ecdf/wizard/ecdf_report.py
+++ b/l10n_lu_ecdf/wizard/ecdf_report.py
@@ -392,7 +392,8 @@ class EcdfReport(models.TransientModel):
                                                      0.0)
 
     @api.multi
-    def _get_finan_report(self, data_current, report_type, data_previous=None):
+    def _get_finan_report(self, data_current, report_type, report_model,
+                          data_previous=None):
         '''
         Generates a financial report (P&L or Balance Sheet) in XML format
         :param data_current: dictionary of data of the current year
@@ -415,7 +416,7 @@ class EcdfReport(models.TransientModel):
         declaration = etree.Element('Declaration',
                                     type=report_type,
                                     language=self.get_language(),
-                                    model='1')
+                                    model=report_model)
         year = etree.Element('Year')
         year.text = datetime.strptime(period_from.date_start,
                                       "%Y-%m-%d").strftime("%Y")
@@ -445,7 +446,7 @@ class EcdfReport(models.TransientModel):
         return declaration
 
     @api.multi
-    def _get_chart_ac(self, data, report_type):
+    def _get_chart_ac(self, data, report_type, report_model):
         '''
         Generates the chart of accounts in XML format
         :param data: Dictionary of values (name, technical name, value)
@@ -471,7 +472,7 @@ class EcdfReport(models.TransientModel):
         declaration = etree.Element('Declaration',
                                     type=report_type,
                                     language=self.get_language(),
-                                    model='1')
+                                    model=report_model)
         year = etree.Element('Year')
         year.text = datetime.strptime(period_from.date_start,
                                       "%Y-%m-%d").strftime("%Y")
@@ -651,20 +652,25 @@ class EcdfReport(models.TransientModel):
         # Report
         if self.with_ac:  # Chart of Accounts
             reports.append({'type': 'CA_PLANCOMPTA',
+                            'model': '1',
                             'templ': templ['CA_PLANCOMPTA']})
         if self.with_bs:  # Balance Sheet
             if self.reports_type == 'full':
                 reports.append({'type': 'CA_BILAN',
+                                'model': '1',
                                 'templ': templ['CA_BILAN']})
             else:  # Balance Sheet abreviated
                 reports.append({'type': 'CA_BILANABR',
+                                'model': '1',
                                 'templ': templ['CA_BILANABR']})
         if self.with_pl:  # Profit and Loss
             if self.reports_type == 'full':
                 reports.append({'type': 'CA_COMPP',
+                                'model': '2',
                                 'templ': templ['CA_COMPP']})
             else:  # Profit and Loss abreviated
                 reports.append({'type': 'CA_COMPPABR',
+                                'model': '1',
                                 'templ': templ['CA_COMPPABR']})
 
         if not reports:
@@ -692,12 +698,14 @@ class EcdfReport(models.TransientModel):
                                                  self.prev_fiscyear)
                 financial_report = self._get_finan_report(data_current,
                                                           report['type'],
+                                                          report['model'],
                                                           data_previous)
                 if financial_report is not None:
                     declarer.append(financial_report)
             else:  # Chart of accounts
                 chart_of_account = self._get_chart_ac(data_current,
-                                                      report['type'])
+                                                      report['type'],
+                                                      report['model'])
                 if chart_of_account is not None:
                     declarer.append(chart_of_account)
 

--- a/l10n_lu_ecdf/wizard/ecdf_report.py
+++ b/l10n_lu_ecdf/wizard/ecdf_report.py
@@ -63,6 +63,7 @@ class EcdfReport(models.TransientModel):
                                      ('abbreviated', 'Abbreviated')),
                                     'Reports Type',
                                     default='full',
+                                    readonly=True,
                                     required=True)
     # Fiscal years
     current_fiscyear = fields.Many2one('account.fiscalyear',
@@ -641,9 +642,9 @@ class EcdfReport(models.TransientModel):
         reports = []
         templ = {
             'CA_PLANCOMPTA': 'l10n_lu_mis_reports.mis_report_ca',
-            'CA_BILAN': 'l10n_lu_mis_reports.mis_report_bs',
+            'CA_BILAN': 'l10n_lu_mis_reports.mis_report_bs_2016',
             'CA_BILANABR': 'l10n_lu_mis_reports.mis_report_abr_bs',
-            'CA_COMPP': 'l10n_lu_mis_reports.mis_report_pl',
+            'CA_COMPP': 'l10n_lu_mis_reports.mis_report_pl_2016',
             'CA_COMPPABR': 'l10n_lu_mis_reports.mis_report_abr_pl',
         }
 

--- a/l10n_lu_mis_reports/README.rst
+++ b/l10n_lu_mis_reports/README.rst
@@ -25,10 +25,12 @@ Accounting > Reporting > MIS Reports and create report instance
 according to the desired time periods and using one of the following
 templates provided by this module:
 
-* Luxembourg Profit & Loss
-* Luxembourg Balance Sheet
-* Luxembourg Profit & Loss (abbreviated)
-* Luxembourg Balance Sheet (abbreviated)
+* Luxembourg Profit & Loss (2016-2017 model)
+* Luxembourg Balance Sheet (2016-2017 model)
+* Luxembourg Profit & Loss (2015 model)
+* Luxembourg Balance Sheet (2015 model)
+* Luxembourg Profit & Loss (abbreviated, 2015 model)
+* Luxembourg Balance Sheet (abbreviated, 2015 model)
 
 To obtain correct results, the account codes prefixes must match the official
 Luxembourg chart of account.

--- a/l10n_lu_mis_reports/__openerp__.py
+++ b/l10n_lu_mis_reports/__openerp__.py
@@ -4,7 +4,7 @@
 #     This file is part of l10n_lu_mis_reports,
 #     an Odoo module.
 #
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#     Copyright (c) 2015-2017 ACSONE SA/NV (<http://acsone.eu>)
 #
 #     l10n_lu_mis_reports is free software:
 #     you can redistribute it and/or modify it under the terms of the GNU
@@ -37,7 +37,9 @@
     ],
     'data': [
         'data/mis_report_pl.xml',
+        'data/mis_report_pl_2016.xml',
         'data/mis_report_bs.xml',
+        'data/mis_report_bs_2016.xml',
         'data/mis_report_ca.xml',
         'data/mis_report_abr_pl.xml',
         'data/mis_report_abr_bs.xml',

--- a/l10n_lu_mis_reports/data/mis_report_abr_bs.xml
+++ b/l10n_lu_mis_reports/data/mis_report_abr_bs.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2015 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
     <record id="mis_report_abr_bs" model="mis.report">
-      <field name="name">Luxembourg Balance Sheet (abbreviated)</field>
+      <field name="name">Luxembourg Balance Sheet (abbreviated, ecdf 2015)</field>
     </record>
     <record id="mis_report_abr_bs_ecdf_202_201" model="mis.report.kpi">
       <field ref="mis_report_abr_bs" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_abr_pl.xml
+++ b/l10n_lu_mis_reports/data/mis_report_abr_pl.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2015 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
     <record id="mis_report_abr_pl" model="mis.report">
-      <field name="name">Luxembourg Profit &amp; Loss (abbreviated)</field>
+      <field name="name">Luxembourg Profit &amp; Loss (abbreviated, ecdf 2015)</field>
     </record>
     <record id="mis_report_abr_pl_ecdf_642_641" model="mis.report.kpi">
       <field ref="mis_report_abr_pl" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_bs.xml
+++ b/l10n_lu_mis_reports/data/mis_report_bs.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2015 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
     <record id="mis_report_bs" model="mis.report">
-      <field name="name">Luxembourg Balance Sheet</field>
+      <field name="name">Luxembourg Balance Sheet (ecdf 2015)</field>
     </record>
     <record id="mis_report_bs_ecdf_202_201" model="mis.report.kpi">
       <field ref="mis_report_bs" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
@@ -1,0 +1,1145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<openerp>
+  <data>
+    <record model="mis.report" id="mis_report_bs_2016">
+      <field name="name">Luxembourg Balance Sheet (ecdf 2016-2017)</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_102_101">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_102_101</field>
+      <field name="description">A. Capital souscrit non versé</field>
+      <field name="expression">ecdf_104_103 + ecdf_106_105</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">10</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_104_103">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_104_103</field>
+      <field name="description">I. Capital souscrit non appelé</field>
+      <field name="expression">bale[102%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">20</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_106_105">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_106_105</field>
+      <field name="description">II. Capital souscrit appelé et non versé</field>
+      <field name="expression">bale[103%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">30</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_108_107">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_108_107</field>
+      <field name="description">B. Frais d’établissement</field>
+      <field name="expression">bale[20%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">40</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_110_109">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_110_109</field>
+      <field name="description">C. Actif immobilisé</field>
+      <field name="expression">ecdf_112_111 + ecdf_126_125 + ecdf_136_135</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">50</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_112_111">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_112_111</field>
+      <field name="description">I. Immobilisations incorporelles</field>
+      <field name="expression">ecdf_114_113 + ecdf_116_115 + ecdf_122_121 + ecdf_124_123</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">60</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_114_113">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_114_113</field>
+      <field name="description">1 Frais de développement</field>
+      <field name="expression">bale[211%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">70</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_116_115">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_116_115</field>
+      <field name="description">2 Concessions, brevets, licences, marques, ainsi que droits et valeurs similaires s’ils ont été</field>
+      <field name="expression">ecdf_118_117 + ecdf_120_119</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">80</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_118_117">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_118_117</field>
+      <field name="description">a) acquis à titre onéreux, sans devoir figurer sous C.I.3</field>
+      <field name="expression">bale[2121%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">90</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_120_119">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_120_119</field>
+      <field name="description">b) créés par l’entreprise elle-même</field>
+      <field name="expression">bale[2122%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">100</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_122_121">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_122_121</field>
+      <field name="description">3 Fonds de commerce, dans la mesure où il a été acquis à titre onéreux</field>
+      <field name="expression">bale[213%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">110</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_124_123">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_124_123</field>
+      <field name="description">4 Acomptes versés et immobilisations incorporelles en cours</field>
+      <field name="expression">bale[214%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">120</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_126_125">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_126_125</field>
+      <field name="description">II. Immobilisations corporelles</field>
+      <field name="expression">ecdf_128_127 + ecdf_130_129 + ecdf_132_131 + ecdf_134_133</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">130</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_128_127">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_128_127</field>
+      <field name="description">1 Terrains et constructions</field>
+      <field name="expression">bale[221%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">140</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_130_129">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_130_129</field>
+      <field name="description">2 Installations techniques et machines</field>
+      <field name="expression">bale[222%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">150</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_132_131">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_132_131</field>
+      <field name="description">3 Autres installations, outillage et mobilier</field>
+      <field name="expression">bale[223%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">160</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_134_133">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_134_133</field>
+      <field name="description">4 Acomptes versés et immobilisations corporelles en cours</field>
+      <field name="expression">bale[224%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">170</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_136_135">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_136_135</field>
+      <field name="description">III. Immobilisations financières</field>
+      <field name="expression">ecdf_138_137 + ecdf_140_139 + ecdf_142_141 + ecdf_144_143 + ecdf_146_145 + ecdf_148_147</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">180</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_138_137">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_138_137</field>
+      <field name="description">1 Parts dans des entreprises liées</field>
+      <field name="expression">bale[231%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">190</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_140_139">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_140_139</field>
+      <field name="description">2 Créances sur des entreprises liées</field>
+      <field name="expression">bale[232%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">200</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_142_141">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_142_141</field>
+      <field name="description">3 Participations</field>
+      <field name="expression">bale[233%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">210</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_144_143">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_144_143</field>
+      <field name="description">4 Créances sur des entreprises avec lesquelles l'entreprise a un lien de participation</field>
+      <field name="expression">bale[234%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">220</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_146_145">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_146_145</field>
+      <field name="description">5 Titres ayant le caractère d’immobilisations</field>
+      <field name="expression">bale[235%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">230</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_148_147">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_148_147</field>
+      <field name="description">6 Autres prêts</field>
+      <field name="expression">bale[236%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">240</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_152_151">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_152_151</field>
+      <field name="description">D. Actif circulant</field>
+      <field name="expression">ecdf_154_153 + ecdf_164_163 + ecdf_190_189 + ecdf_198_197</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">250</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_154_153">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_154_153</field>
+      <field name="description">I. Stocks</field>
+      <field name="expression">ecdf_156_155 + ecdf_158_157 + ecdf_160_159 + ecdf_162_161</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">260</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_156_155">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_156_155</field>
+      <field name="description">1 Matières premières et consommables</field>
+      <field name="expression">bale[30%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">270</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_158_157">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_158_157</field>
+      <field name="description">2 Produits en cours de fabrication</field>
+      <field name="expression">bale[31%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">280</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_160_159">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_160_159</field>
+      <field name="description">3 Produits finis et marchandises</field>
+      <field name="expression">bale[32%,33%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">290</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_162_161">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_162_161</field>
+      <field name="description">4 Acomptes versés</field>
+      <field name="expression">bale[34%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">300</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_164_163">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_164_163</field>
+      <field name="description">II. Créances</field>
+      <field name="expression">ecdf_166_165 + ecdf_172_171 + ecdf_178_177 + ecdf_184_183</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">310</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_166_165">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_166_165</field>
+      <field name="description">1 Créances résultant de ventes et prestations de services</field>
+      <field name="expression">ecdf_168_167 + ecdf_170_169</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">320</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_168_167">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_168_167</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">bale[401%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">330</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_170_169">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_170_169</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">bale[402%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">340</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_172_171">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_172_171</field>
+      <field name="description">2 Créances sur des entreprises liées</field>
+      <field name="expression">ecdf_174_173 + ecdf_176_175</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">350</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_174_173">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_174_173</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">bale[4111%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">360</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_176_175">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_176_175</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">bale[4112%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">370</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_178_177">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_178_177</field>
+      <field name="description">3 Créances sur des entreprises avec lesquelles l'entreprise a un lien de participation</field>
+      <field name="expression">ecdf_180_179 + ecdf_182_181</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">380</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_180_179">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_180_179</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">bale[4121%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">390</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_182_181">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_182_181</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">bale[4122%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">400</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_184_183">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_184_183</field>
+      <field name="description">4 Autres créances</field>
+      <field name="expression">ecdf_186_185 + ecdf_188_187</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">410</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_186_185">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_186_185</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">bale[421%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">420</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_188_187">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_188_187</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">bale[422%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">430</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_190_189">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_190_189</field>
+      <field name="description">III. Valeurs mobilières</field>
+      <field name="expression">ecdf_192_191 + ecdf_210_209 + ecdf_196_195</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">440</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_192_191">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_192_191</field>
+      <field name="description">1 Parts dans des entreprises liées</field>
+      <field name="expression">bale[501%,502%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">450</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_210_209">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_210_209</field>
+      <field name="description">2 Actions propres ou parts propres</field>
+      <field name="expression">bale[237%,503%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">460</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_196_195">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_196_195</field>
+      <field name="description">3 Autres valeurs mobilières</field>
+      <field name="expression">bale[508%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">470</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_198_197">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_198_197</field>
+      <field name="description">IV. Avoirs en banques, avoirs en compte de chèques postaux, chèques et encaisse</field>
+      <field name="expression">bale[51%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">480</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_200_199">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_200_199</field>
+      <field name="description">E. Comptes de régularisation</field>
+      <field name="expression">bale[481%,484%,486%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">490</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_202_201">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_202_201</field>
+      <field name="description">TOTAL DU BILAN (ACTIF)</field>
+      <field name="expression">ecdf_102_101 + ecdf_108_107 + ecdf_110_109 + ecdf_152_151 + ecdf_200_199</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">background-color: orange; font-weight: bold</field>
+      <field name="sequence">500</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_302_301">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_302_301</field>
+      <field name="description">A. Capitaux propres</field>
+      <field name="expression">ecdf_304_303 + ecdf_306_305 + ecdf_308_307 + ecdf_310_309 + ecdf_320_319 +ecdf_322_321 + ecdf_324_323 + ecdf_326_325</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">510</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_304_303">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_304_303</field>
+      <field name="description">I. Capital souscrit</field>
+      <field name="expression">-bale[101%,104%,105%,106%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">520</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_306_305">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_306_305</field>
+      <field name="description">II. Primes d'émission</field>
+      <field name="expression">-bale[11%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">530</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_308_307">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_308_307</field>
+      <field name="description">III. Réserve de réévaluation</field>
+      <field name="expression">-bale[12%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">540</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_310_309">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_310_309</field>
+      <field name="description">IV. Réserves</field>
+      <field name="expression">ecdf_312_311 + ecdf_314_313 + ecdf_316_315 + ecdf_430_429</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">550</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_312_311">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_312_311</field>
+      <field name="description">1 Réserve légale</field>
+      <field name="expression">-bale[131%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">560</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_314_313">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_314_313</field>
+      <field name="description">2 Réserve pour actions propres ou parts propres</field>
+      <field name="expression">-bale[132%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">570</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_316_315">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_316_315</field>
+      <field name="description">3 Réserves statutaires</field>
+      <field name="expression">-bale[133%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">580</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_430_429">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_430_429</field>
+      <field name="description">4 Autres réserves, y compris la réserve de juste valeur</field>
+      <field name="expression">ecdf_432_431 + ecdf_434_433</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">590</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_432_431">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_432_431</field>
+      <field name="description">a) autres réserves disponibles</field>
+      <field name="expression">-bale[1383%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">600</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_434_433">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_434_433</field>
+      <field name="description">b) autres réserves non disponibles</field>
+      <field name="expression">-bale[1381%,1382%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">610</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_320_319">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_320_319</field>
+      <field name="description">V. Résultats reportés</field>
+      <field name="expression">-bale[141%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">620</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_322_321">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_322_321</field>
+      <field name="description">VI. Résultat de l'exercice</field>
+      <field name="expression">-bale[142%,6%,7%,869%,879%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">630</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_324_323">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_324_323</field>
+      <field name="description">VII. Acomptes sur dividendes</field>
+      <field name="expression">-bale[15%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">640</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_326_325">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_326_325</field>
+      <field name="description">VIII. Subventions d’investissement en capital</field>
+      <field name="expression">ecdf_334_333 + ecdf_336_335 + ecdf_338_337</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">650</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_332_331">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_332_331</field>
+      <field name="description">B. Provisions</field>
+      <field name="expression">ecdf_334_333 + ecdf_336_335 + ecdf_338_337</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">660</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_334_333">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_334_333</field>
+      <field name="description">1 Provisions pour pensions et obligations similaires</field>
+      <field name="expression">-bale[181%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">670</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_336_335">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_336_335</field>
+      <field name="description">2 Provisions pour impôts</field>
+      <field name="expression">-bale[182%,183%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">680</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_338_337">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_338_337</field>
+      <field name="description">3 Autres provisions</field>
+      <field name="expression">-bale[188%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">690</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_436_435">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_436_435</field>
+      <field name="description">C. Dettes</field>
+      <field name="expression">ecdf_438_437 + ecdf_356_355 + ecdf_362_361 + ecdf_368_367 + ecdf_374_373 + ecdf_380_379 + ecdf_386_385 + ecdf_452_451</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">700</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_438_437">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_438_437</field>
+      <field name="description">1 Emprunts obligataires</field>
+      <field name="expression">ecdf_440_439 + ecdf_446_445</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">710</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_440_439">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_440_439</field>
+      <field name="description">a) Emprunts convertibles</field>
+      <field name="expression">ecdf_442_441 + ecdf_444_443</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">720</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_442_441">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_442_441</field>
+      <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[1921%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">730</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_444_443">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_444_443</field>
+      <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[1922%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">740</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_446_445">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_446_445</field>
+      <field name="description">b) Emprunts non convertibles</field>
+      <field name="expression">ecdf_448_447 + ecdf_450_449</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">750</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_448_447">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_448_447</field>
+      <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[1931%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">760</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_450_449">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_450_449</field>
+      <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[1932%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">770</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_356_355">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_356_355</field>
+      <field name="description">2 Dettes envers des établissements de crédit</field>
+      <field name="expression">ecdf_358_357 + ecdf_360_359</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">780</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_358_357">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_358_357</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[1941%,1951%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">790</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_360_359">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_360_359</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[1942%,1952%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">800</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_362_361">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_362_361</field>
+      <field name="description">3 Acomptes reçus sur commandes pour autant qu’ils ne sont pas déduits des stocks de façon distincte</field>
+      <field name="expression">ecdf_364_363 + ecdf_366_365</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">810</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_364_363">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_364_363</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[431%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">820</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_366_365">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_366_365</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[432%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">830</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_368_367">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_368_367</field>
+      <field name="description">4 Dettes sur achats et prestations de services</field>
+      <field name="expression">ecdf_370_369 + ecdf_372_371</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">840</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_370_369">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_370_369</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[4411%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">850</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_372_371">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_372_371</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[4412%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">860</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_374_373">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_374_373</field>
+      <field name="description">5 Dettes représentées par des effets de commerce</field>
+      <field name="expression">ecdf_376_375 + ecdf_378_377</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">870</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_376_375">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_376_375</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[4421%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">880</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_378_377">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_378_377</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[4422%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">890</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_380_379">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_380_379</field>
+      <field name="description">6 Dettes envers des entreprises liées</field>
+      <field name="expression">ecdf_382_381 + ecdf_384_383</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">900</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_382_381">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_382_381</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[4511%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">910</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_384_383">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_384_383</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[4512%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">920</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_386_385">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_386_385</field>
+      <field name="description">7 Dettes envers des entreprises avec lesquelles l'entreprise a un lien de participation</field>
+      <field name="expression">ecdf_388_387 + ecdf_390_389</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">930</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_388_387">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_388_387</field>
+      <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[4521%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">940</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_390_389">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_390_389</field>
+      <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[4522%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">950</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_452_451">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_452_451</field>
+      <field name="description">8 Autres dettes</field>
+      <field name="expression">ecdf_394_393 + ecdf_396_395 + ecdf_398_397</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">960</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_394_393">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_394_393</field>
+      <field name="description">a) Dettes fiscales</field>
+      <field name="expression">-bale[461%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">970</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_396_395">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_396_395</field>
+      <field name="description">b) Dettes au titre de la sécurité sociale</field>
+      <field name="expression">-bale[462%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">980</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_398_397">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_398_397</field>
+      <field name="description">c) Autres dettes</field>
+      <field name="expression">ecdf_400_399 + ecdf_402_401</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">990</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_400_399">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_400_399</field>
+      <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
+      <field name="expression">-bale[1981%,471%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">1000</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_402_401">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_402_401</field>
+      <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
+      <field name="expression">-bale[1982%,472%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">1010</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_404_403">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_404_403</field>
+      <field name="description">D. Comptes de régularisation</field>
+      <field name="expression">-bale[482%,483%,485%,487%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">1020</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_406_405">
+      <field ref="mis_report_bs_2016" name="report_id"/>
+      <field name="name">ecdf_406_405</field>
+      <field name="description">TOTAL DU BILAN (CAPITAUX PROPRES ET PASSIF)</field>
+      <field name="expression">ecdf_302_301 + ecdf_332_331 + ecdf_436_435 + ecdf_404_403</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">background-color: orange; font-weight: bold</field>
+      <field name="sequence">1030</field>
+    </record>
+  </data>
+</openerp>

--- a/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
@@ -1,1143 +1,1142 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2017 ACSONE SA/NV
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <openerp>
   <data>
-    <record model="mis.report" id="mis_report_bs_2016">
+    <record id="mis_report_bs_2016" model="mis.report">
       <field name="name">Luxembourg Balance Sheet (ecdf 2016-2017)</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_102_101">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_102_101" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_102_101</field>
       <field name="description">A. Capital souscrit non versé</field>
       <field name="expression">ecdf_104_103 + ecdf_106_105</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">10</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_104_103">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_104_103" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_104_103</field>
       <field name="description">I. Capital souscrit non appelé</field>
       <field name="expression">bale[102%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">20</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_106_105">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_106_105" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_106_105</field>
       <field name="description">II. Capital souscrit appelé et non versé</field>
       <field name="expression">bale[103%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">30</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_108_107">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_108_107" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_108_107</field>
       <field name="description">B. Frais d’établissement</field>
       <field name="expression">bale[20%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">40</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_110_109">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_110_109" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_110_109</field>
       <field name="description">C. Actif immobilisé</field>
       <field name="expression">ecdf_112_111 + ecdf_126_125 + ecdf_136_135</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">50</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_112_111">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_112_111" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_112_111</field>
       <field name="description">I. Immobilisations incorporelles</field>
       <field name="expression">ecdf_114_113 + ecdf_116_115 + ecdf_122_121 + ecdf_124_123</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">60</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_114_113">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_114_113" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_114_113</field>
       <field name="description">1 Frais de développement</field>
       <field name="expression">bale[211%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">70</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_116_115">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_116_115" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_116_115</field>
       <field name="description">2 Concessions, brevets, licences, marques, ainsi que droits et valeurs similaires s’ils ont été</field>
       <field name="expression">ecdf_118_117 + ecdf_120_119</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">80</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_118_117">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_118_117" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_118_117</field>
       <field name="description">a) acquis à titre onéreux, sans devoir figurer sous C.I.3</field>
       <field name="expression">bale[2121%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">90</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_120_119">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_120_119" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_120_119</field>
       <field name="description">b) créés par l’entreprise elle-même</field>
       <field name="expression">bale[2122%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">100</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_122_121">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_122_121" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_122_121</field>
       <field name="description">3 Fonds de commerce, dans la mesure où il a été acquis à titre onéreux</field>
       <field name="expression">bale[213%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">110</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_124_123">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_124_123" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_124_123</field>
       <field name="description">4 Acomptes versés et immobilisations incorporelles en cours</field>
       <field name="expression">bale[214%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">120</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_126_125">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_126_125" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_126_125</field>
       <field name="description">II. Immobilisations corporelles</field>
       <field name="expression">ecdf_128_127 + ecdf_130_129 + ecdf_132_131 + ecdf_134_133</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">130</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_128_127">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_128_127" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_128_127</field>
       <field name="description">1 Terrains et constructions</field>
       <field name="expression">bale[221%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">140</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_130_129">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_130_129" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_130_129</field>
       <field name="description">2 Installations techniques et machines</field>
       <field name="expression">bale[222%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">150</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_132_131">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_132_131" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_132_131</field>
       <field name="description">3 Autres installations, outillage et mobilier</field>
       <field name="expression">bale[223%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">160</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_134_133">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_134_133" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_134_133</field>
       <field name="description">4 Acomptes versés et immobilisations corporelles en cours</field>
       <field name="expression">bale[224%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">170</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_136_135">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_136_135" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_136_135</field>
       <field name="description">III. Immobilisations financières</field>
       <field name="expression">ecdf_138_137 + ecdf_140_139 + ecdf_142_141 + ecdf_144_143 + ecdf_146_145 + ecdf_148_147</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">180</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_138_137">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_138_137" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_138_137</field>
       <field name="description">1 Parts dans des entreprises liées</field>
       <field name="expression">bale[231%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">190</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_140_139">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_140_139" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_140_139</field>
       <field name="description">2 Créances sur des entreprises liées</field>
       <field name="expression">bale[232%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">200</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_142_141">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_142_141" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_142_141</field>
       <field name="description">3 Participations</field>
       <field name="expression">bale[233%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">210</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_144_143">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_144_143" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_144_143</field>
       <field name="description">4 Créances sur des entreprises avec lesquelles l'entreprise a un lien de participation</field>
       <field name="expression">bale[234%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">220</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_146_145">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_146_145" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_146_145</field>
       <field name="description">5 Titres ayant le caractère d’immobilisations</field>
       <field name="expression">bale[235%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">230</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_148_147">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_148_147" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_148_147</field>
       <field name="description">6 Autres prêts</field>
       <field name="expression">bale[236%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">240</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_152_151">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_152_151" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_152_151</field>
       <field name="description">D. Actif circulant</field>
       <field name="expression">ecdf_154_153 + ecdf_164_163 + ecdf_190_189 + ecdf_198_197</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">250</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_154_153">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_154_153" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_154_153</field>
       <field name="description">I. Stocks</field>
       <field name="expression">ecdf_156_155 + ecdf_158_157 + ecdf_160_159 + ecdf_162_161</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">260</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_156_155">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_156_155" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_156_155</field>
       <field name="description">1 Matières premières et consommables</field>
       <field name="expression">bale[30%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">270</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_158_157">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_158_157" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_158_157</field>
       <field name="description">2 Produits en cours de fabrication</field>
       <field name="expression">bale[31%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">280</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_160_159">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_160_159" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_160_159</field>
       <field name="description">3 Produits finis et marchandises</field>
       <field name="expression">bale[32%,33%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">290</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_162_161">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_162_161" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_162_161</field>
       <field name="description">4 Acomptes versés</field>
       <field name="expression">bale[34%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">300</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_164_163">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_164_163" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_164_163</field>
       <field name="description">II. Créances</field>
       <field name="expression">ecdf_166_165 + ecdf_172_171 + ecdf_178_177 + ecdf_184_183</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">310</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_166_165">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_166_165" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_166_165</field>
       <field name="description">1 Créances résultant de ventes et prestations de services</field>
       <field name="expression">ecdf_168_167 + ecdf_170_169</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">320</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_168_167">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_168_167" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_168_167</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">bale[401%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">330</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_170_169">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_170_169" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_170_169</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">bale[402%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">340</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_172_171">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_172_171" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_172_171</field>
       <field name="description">2 Créances sur des entreprises liées</field>
       <field name="expression">ecdf_174_173 + ecdf_176_175</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">350</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_174_173">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_174_173" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_174_173</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">bale[4111%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">360</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_176_175">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_176_175" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_176_175</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">bale[4112%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">370</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_178_177">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_178_177" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_178_177</field>
       <field name="description">3 Créances sur des entreprises avec lesquelles l'entreprise a un lien de participation</field>
       <field name="expression">ecdf_180_179 + ecdf_182_181</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">380</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_180_179">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_180_179" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_180_179</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">bale[4121%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">390</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_182_181">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_182_181" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_182_181</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">bale[4122%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">400</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_184_183">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_184_183" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_184_183</field>
       <field name="description">4 Autres créances</field>
       <field name="expression">ecdf_186_185 + ecdf_188_187</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">410</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_186_185">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_186_185" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_186_185</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">bale[421%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">420</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_188_187">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_188_187" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_188_187</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">bale[422%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">430</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_190_189">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_190_189" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_190_189</field>
       <field name="description">III. Valeurs mobilières</field>
       <field name="expression">ecdf_192_191 + ecdf_210_209 + ecdf_196_195</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">440</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_192_191">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_192_191" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_192_191</field>
       <field name="description">1 Parts dans des entreprises liées</field>
       <field name="expression">bale[501%,502%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">450</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_210_209">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_210_209" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_210_209</field>
       <field name="description">2 Actions propres ou parts propres</field>
       <field name="expression">bale[237%,503%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">460</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_196_195">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_196_195" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_196_195</field>
       <field name="description">3 Autres valeurs mobilières</field>
       <field name="expression">bale[508%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">470</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_198_197">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_198_197" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_198_197</field>
       <field name="description">IV. Avoirs en banques, avoirs en compte de chèques postaux, chèques et encaisse</field>
       <field name="expression">bale[51%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">480</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_200_199">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_200_199" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_200_199</field>
       <field name="description">E. Comptes de régularisation</field>
       <field name="expression">bale[481%,484%,486%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">490</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_202_201">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_202_201" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_202_201</field>
       <field name="description">TOTAL DU BILAN (ACTIF)</field>
       <field name="expression">ecdf_102_101 + ecdf_108_107 + ecdf_110_109 + ecdf_152_151 + ecdf_200_199</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">background-color: orange; font-weight: bold</field>
       <field name="sequence">500</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_302_301">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_302_301" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_302_301</field>
       <field name="description">A. Capitaux propres</field>
       <field name="expression">ecdf_304_303 + ecdf_306_305 + ecdf_308_307 + ecdf_310_309 + ecdf_320_319 +ecdf_322_321 + ecdf_324_323 + ecdf_326_325</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">510</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_304_303">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_304_303" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_304_303</field>
       <field name="description">I. Capital souscrit</field>
       <field name="expression">-bale[101%,104%,105%,106%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">520</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_306_305">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_306_305" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_306_305</field>
       <field name="description">II. Primes d'émission</field>
       <field name="expression">-bale[11%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">530</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_308_307">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_308_307" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_308_307</field>
       <field name="description">III. Réserve de réévaluation</field>
       <field name="expression">-bale[12%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">540</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_310_309">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_310_309" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_310_309</field>
       <field name="description">IV. Réserves</field>
       <field name="expression">ecdf_312_311 + ecdf_314_313 + ecdf_316_315 + ecdf_430_429</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">550</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_312_311">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_312_311" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_312_311</field>
       <field name="description">1 Réserve légale</field>
       <field name="expression">-bale[131%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">560</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_314_313">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_314_313" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_314_313</field>
       <field name="description">2 Réserve pour actions propres ou parts propres</field>
       <field name="expression">-bale[132%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">570</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_316_315">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_316_315" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_316_315</field>
       <field name="description">3 Réserves statutaires</field>
       <field name="expression">-bale[133%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">580</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_430_429">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_430_429" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_430_429</field>
       <field name="description">4 Autres réserves, y compris la réserve de juste valeur</field>
       <field name="expression">ecdf_432_431 + ecdf_434_433</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">590</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_432_431">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_432_431" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_432_431</field>
       <field name="description">a) autres réserves disponibles</field>
       <field name="expression">-bale[1383%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">600</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_434_433">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_434_433" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_434_433</field>
       <field name="description">b) autres réserves non disponibles</field>
       <field name="expression">-bale[1381%,1382%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">610</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_320_319">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_320_319" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_320_319</field>
       <field name="description">V. Résultats reportés</field>
       <field name="expression">-bale[141%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">620</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_322_321">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_322_321" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_322_321</field>
       <field name="description">VI. Résultat de l'exercice</field>
       <field name="expression">-bale[142%,6%,7%,869%,879%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">630</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_324_323">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_324_323" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_324_323</field>
       <field name="description">VII. Acomptes sur dividendes</field>
       <field name="expression">-bale[15%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">640</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_326_325">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_326_325" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_326_325</field>
       <field name="description">VIII. Subventions d’investissement en capital</field>
       <field name="expression">ecdf_334_333 + ecdf_336_335 + ecdf_338_337</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">650</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_332_331">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_332_331" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_332_331</field>
       <field name="description">B. Provisions</field>
       <field name="expression">ecdf_334_333 + ecdf_336_335 + ecdf_338_337</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">660</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_334_333">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_334_333" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_334_333</field>
       <field name="description">1 Provisions pour pensions et obligations similaires</field>
       <field name="expression">-bale[181%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">670</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_336_335">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_336_335" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_336_335</field>
       <field name="description">2 Provisions pour impôts</field>
       <field name="expression">-bale[182%,183%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">680</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_338_337">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_338_337" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_338_337</field>
       <field name="description">3 Autres provisions</field>
       <field name="expression">-bale[188%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">690</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_436_435">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_436_435" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_436_435</field>
       <field name="description">C. Dettes</field>
       <field name="expression">ecdf_438_437 + ecdf_356_355 + ecdf_362_361 + ecdf_368_367 + ecdf_374_373 + ecdf_380_379 + ecdf_386_385 + ecdf_452_451</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">700</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_438_437">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_438_437" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_438_437</field>
       <field name="description">1 Emprunts obligataires</field>
       <field name="expression">ecdf_440_439 + ecdf_446_445</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">710</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_440_439">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_440_439" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_440_439</field>
       <field name="description">a) Emprunts convertibles</field>
       <field name="expression">ecdf_442_441 + ecdf_444_443</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">720</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_442_441">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_442_441" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_442_441</field>
       <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[1921%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">730</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_444_443">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_444_443" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_444_443</field>
       <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[1922%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">740</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_446_445">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_446_445" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_446_445</field>
       <field name="description">b) Emprunts non convertibles</field>
       <field name="expression">ecdf_448_447 + ecdf_450_449</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">750</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_448_447">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_448_447" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_448_447</field>
       <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[1931%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">760</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_450_449">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_450_449" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_450_449</field>
       <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[1932%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">770</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_356_355">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_356_355" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_356_355</field>
       <field name="description">2 Dettes envers des établissements de crédit</field>
       <field name="expression">ecdf_358_357 + ecdf_360_359</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">780</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_358_357">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_358_357" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_358_357</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[1941%,1951%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">790</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_360_359">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_360_359" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_360_359</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[1942%,1952%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">800</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_362_361">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_362_361" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_362_361</field>
       <field name="description">3 Acomptes reçus sur commandes pour autant qu’ils ne sont pas déduits des stocks de façon distincte</field>
       <field name="expression">ecdf_364_363 + ecdf_366_365</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">810</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_364_363">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_364_363" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_364_363</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[431%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">820</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_366_365">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_366_365" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_366_365</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[432%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">830</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_368_367">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_368_367" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_368_367</field>
       <field name="description">4 Dettes sur achats et prestations de services</field>
       <field name="expression">ecdf_370_369 + ecdf_372_371</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">840</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_370_369">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_370_369" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_370_369</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[4411%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">850</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_372_371">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_372_371" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_372_371</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[4412%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">860</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_374_373">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_374_373" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_374_373</field>
       <field name="description">5 Dettes représentées par des effets de commerce</field>
       <field name="expression">ecdf_376_375 + ecdf_378_377</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">870</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_376_375">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_376_375" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_376_375</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[4421%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">880</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_378_377">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_378_377" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_378_377</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[4422%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">890</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_380_379">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_380_379" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_380_379</field>
       <field name="description">6 Dettes envers des entreprises liées</field>
       <field name="expression">ecdf_382_381 + ecdf_384_383</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">900</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_382_381">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_382_381" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_382_381</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[4511%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">910</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_384_383">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_384_383" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_384_383</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[4512%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">920</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_386_385">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_386_385" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_386_385</field>
       <field name="description">7 Dettes envers des entreprises avec lesquelles l'entreprise a un lien de participation</field>
       <field name="expression">ecdf_388_387 + ecdf_390_389</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">930</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_388_387">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_388_387" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_388_387</field>
       <field name="description">a) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[4521%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">940</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_390_389">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_390_389" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_390_389</field>
       <field name="description">b) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[4522%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">950</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_452_451">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_452_451" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_452_451</field>
       <field name="description">8 Autres dettes</field>
       <field name="expression">ecdf_394_393 + ecdf_396_395 + ecdf_398_397</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">960</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_394_393">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_394_393" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_394_393</field>
       <field name="description">a) Dettes fiscales</field>
       <field name="expression">-bale[461%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">970</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_396_395">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_396_395" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_396_395</field>
       <field name="description">b) Dettes au titre de la sécurité sociale</field>
       <field name="expression">-bale[462%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">980</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_398_397">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_398_397" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_398_397</field>
       <field name="description">c) Autres dettes</field>
       <field name="expression">ecdf_400_399 + ecdf_402_401</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">990</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_400_399">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_400_399" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_400_399</field>
       <field name="description">i) dont la durée résiduelle est inférieure ou égale à un an</field>
       <field name="expression">-bale[1981%,471%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">1000</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_402_401">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_402_401" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_402_401</field>
       <field name="description">ii) dont la durée résiduelle est supérieure à un an</field>
       <field name="expression">-bale[1982%,472%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">1010</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_404_403">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_404_403" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_404_403</field>
       <field name="description">D. Comptes de régularisation</field>
       <field name="expression">-bale[482%,483%,485%,487%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">1020</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_bs_2016_ecdf_406_405">
-      <field ref="mis_report_bs_2016" name="report_id"/>
+    <record id="mis_report_bs_2016_ecdf_406_405" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_bs_2016"></field>
       <field name="name">ecdf_406_405</field>
       <field name="description">TOTAL DU BILAN (CAPITAUX PROPRES ET PASSIF)</field>
       <field name="expression">ecdf_302_301 + ecdf_332_331 + ecdf_436_435 + ecdf_404_403</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">background-color: orange; font-weight: bold</field>
       <field name="sequence">1030</field>
     </record>

--- a/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_bs_2016.xml
@@ -15,6 +15,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">10</field>
     </record>
@@ -26,6 +27,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">20</field>
     </record>
@@ -37,6 +39,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">30</field>
     </record>
@@ -48,6 +51,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">40</field>
     </record>
@@ -59,6 +63,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">50</field>
     </record>
@@ -70,6 +75,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">60</field>
     </record>
@@ -81,6 +87,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">70</field>
     </record>
@@ -92,6 +99,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">80</field>
     </record>
@@ -103,6 +111,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">90</field>
     </record>
@@ -114,6 +123,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">100</field>
     </record>
@@ -125,6 +135,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">110</field>
     </record>
@@ -136,6 +147,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">120</field>
     </record>
@@ -147,6 +159,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">130</field>
     </record>
@@ -158,6 +171,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">140</field>
     </record>
@@ -169,6 +183,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">150</field>
     </record>
@@ -180,6 +195,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">160</field>
     </record>
@@ -191,6 +207,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">170</field>
     </record>
@@ -202,6 +219,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">180</field>
     </record>
@@ -213,6 +231,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">190</field>
     </record>
@@ -224,6 +243,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">200</field>
     </record>
@@ -235,6 +255,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">210</field>
     </record>
@@ -246,6 +267,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">220</field>
     </record>
@@ -257,6 +279,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">230</field>
     </record>
@@ -268,6 +291,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">240</field>
     </record>
@@ -279,6 +303,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">250</field>
     </record>
@@ -290,6 +315,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">260</field>
     </record>
@@ -301,6 +327,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">270</field>
     </record>
@@ -312,6 +339,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">280</field>
     </record>
@@ -323,6 +351,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">290</field>
     </record>
@@ -334,6 +363,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">300</field>
     </record>
@@ -345,6 +375,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">310</field>
     </record>
@@ -356,6 +387,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">320</field>
     </record>
@@ -367,6 +399,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">330</field>
     </record>
@@ -378,6 +411,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">340</field>
     </record>
@@ -389,6 +423,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">350</field>
     </record>
@@ -400,6 +435,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">360</field>
     </record>
@@ -411,6 +447,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">370</field>
     </record>
@@ -422,6 +459,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">380</field>
     </record>
@@ -433,6 +471,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">390</field>
     </record>
@@ -444,6 +483,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">400</field>
     </record>
@@ -455,6 +495,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">410</field>
     </record>
@@ -466,6 +507,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">420</field>
     </record>
@@ -477,6 +519,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">430</field>
     </record>
@@ -488,6 +531,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">440</field>
     </record>
@@ -499,6 +543,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">450</field>
     </record>
@@ -510,6 +555,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">460</field>
     </record>
@@ -521,6 +567,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">470</field>
     </record>
@@ -532,6 +579,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">480</field>
     </record>
@@ -543,6 +591,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">490</field>
     </record>
@@ -554,6 +603,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">background-color: orange; font-weight: bold</field>
       <field name="sequence">500</field>
     </record>
@@ -565,6 +615,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">510</field>
     </record>
@@ -576,6 +627,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">520</field>
     </record>
@@ -587,6 +639,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">530</field>
     </record>
@@ -598,6 +651,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">540</field>
     </record>
@@ -609,6 +663,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">550</field>
     </record>
@@ -620,6 +675,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">560</field>
     </record>
@@ -631,6 +687,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">570</field>
     </record>
@@ -642,6 +699,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">580</field>
     </record>
@@ -653,6 +711,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">590</field>
     </record>
@@ -664,6 +723,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">600</field>
     </record>
@@ -675,6 +735,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">610</field>
     </record>
@@ -686,6 +747,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">620</field>
     </record>
@@ -697,6 +759,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">630</field>
     </record>
@@ -708,6 +771,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">640</field>
     </record>
@@ -719,6 +783,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">650</field>
     </record>
@@ -730,6 +795,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">660</field>
     </record>
@@ -741,6 +807,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">670</field>
     </record>
@@ -752,6 +819,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">680</field>
     </record>
@@ -763,6 +831,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">690</field>
     </record>
@@ -774,6 +843,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">700</field>
     </record>
@@ -785,6 +855,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">710</field>
     </record>
@@ -796,6 +867,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">720</field>
     </record>
@@ -807,6 +879,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">730</field>
     </record>
@@ -818,6 +891,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">740</field>
     </record>
@@ -829,6 +903,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">750</field>
     </record>
@@ -840,6 +915,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">760</field>
     </record>
@@ -851,6 +927,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">770</field>
     </record>
@@ -862,6 +939,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">780</field>
     </record>
@@ -873,6 +951,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">790</field>
     </record>
@@ -884,6 +963,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">800</field>
     </record>
@@ -895,6 +975,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">810</field>
     </record>
@@ -906,6 +987,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">820</field>
     </record>
@@ -917,6 +999,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">830</field>
     </record>
@@ -928,6 +1011,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">840</field>
     </record>
@@ -939,6 +1023,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">850</field>
     </record>
@@ -950,6 +1035,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">860</field>
     </record>
@@ -961,6 +1047,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">870</field>
     </record>
@@ -972,6 +1059,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">880</field>
     </record>
@@ -983,6 +1071,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">890</field>
     </record>
@@ -994,6 +1083,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">900</field>
     </record>
@@ -1005,6 +1095,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">910</field>
     </record>
@@ -1016,6 +1107,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">920</field>
     </record>
@@ -1027,6 +1119,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">930</field>
     </record>
@@ -1038,6 +1131,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">940</field>
     </record>
@@ -1049,6 +1143,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">950</field>
     </record>
@@ -1060,6 +1155,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">960</field>
     </record>
@@ -1071,6 +1167,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">970</field>
     </record>
@@ -1082,6 +1179,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">980</field>
     </record>
@@ -1093,6 +1191,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">990</field>
     </record>
@@ -1104,6 +1203,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">1000</field>
     </record>
@@ -1115,6 +1215,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">1010</field>
     </record>
@@ -1126,6 +1227,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">1020</field>
     </record>
@@ -1137,6 +1239,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">background-color: orange; font-weight: bold</field>
       <field name="sequence">1030</field>
     </record>

--- a/l10n_lu_mis_reports/data/mis_report_ca.xml
+++ b/l10n_lu_mis_reports/data/mis_report_ca.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2015 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
     <record id="mis_report_ca" model="mis.report">
-      <field name="name">Luxembourg Chart of Accounts</field>
+      <field name="name">Luxembourg Chart of Accounts (ecdf)</field>
     </record>
     <record id="mis_report_ca_ecdf_1111_1112" model="mis.report.kpi">
       <field ref="mis_report_ca" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_pl.xml
+++ b/l10n_lu_mis_reports/data/mis_report_pl.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2015 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
     <record id="mis_report_pl" model="mis.report">
-      <field name="name">Luxembourg Profit &amp; Loss</field>
+      <field name="name">Luxembourg Profit &amp; Loss (ecdf 2015)</field>
     </record>
     <record id="mis_report_pl_ecdf_642_641" model="mis.report.kpi">
       <field ref="mis_report_pl" name="report_id"/>

--- a/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
@@ -1,417 +1,416 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2017 ACSONE SA/NV
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <openerp>
   <data>
-    <record model="mis.report" id="mis_report_pl_2016">
+    <record id="mis_report_pl_2016" model="mis.report">
       <field name="name">Luxembourg Profit &amp; Loss (ecdf 2016-2017)</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_702_701">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_702_701" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_702_701</field>
       <field name="description">1 Chiffre d'affaires net</field>
       <field name="expression">-balp[70%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">10</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_704_703">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_704_703" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_704_703</field>
       <field name="description">2 Variation du stock de produits finis et en cours de fabrication</field>
       <field name="expression">-balp[71%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">20</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_706_705">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_706_705" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_706_705</field>
       <field name="description">3 Travaux effectués par l'entreprise pour elle-même et portés à l'actif</field>
       <field name="expression">-balp[72%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">30</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_714_713">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_714_713" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_714_713</field>
       <field name="description">4 Autres produits d'exploitation</field>
       <field name="expression">-balp[74%,768%,769%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">40</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_672_671">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_672_671" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_672_671</field>
       <field name="description">5 Matières premières et consommables et autres charges externes</field>
       <field name="expression">ecdf_602_601 + ecdf_604_603</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">50</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_602_601">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_602_601" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_602_601</field>
       <field name="description">a) Matières premières et consommables</field>
       <field name="expression">-balp[60%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">60</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_604_603">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_604_603" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_604_603</field>
       <field name="description">b) Autres charges externes</field>
       <field name="expression">-balp[61%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">70</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_606_605">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_606_605" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_606_605</field>
       <field name="description">6 Frais de personnel</field>
       <field name="expression">ecdf_608_607 + ecdf_610_609 + ecdf_614_613</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">80</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_608_607">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_608_607" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_608_607</field>
       <field name="description">a) Salaires et traitements</field>
       <field name="expression">-balp[621%,622%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">90</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_610_609">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_610_609" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_610_609</field>
       <field name="description">b) Charges sociales</field>
       <field name="expression">ecdf_654_653 + ecdf_656_655</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">100</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_654_653">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_654_653" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_654_653</field>
       <field name="description">i) couvrant les pensions</field>
       <field name="expression">-balp[624%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">110</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_656_655">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_656_655" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_656_655</field>
       <field name="description">ii) autres charges sociales</field>
       <field name="expression">-balp[623%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">120</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_614_613">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_614_613" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_614_613</field>
       <field name="description">c) Autres frais de personnel</field>
       <field name="expression">-balp[628%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">130</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_658_657">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_658_657" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_658_657</field>
       <field name="description">7 Corrections de valeur</field>
       <field name="expression">ecdf_660_659 + ecdf_662_661</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">140</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_660_659">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_660_659" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_660_659</field>
       <field name="description">a) sur frais d'établissement et sur immobilisations corporelles et incorporelles</field>
       <field name="expression">-balp[631%,632%,633%,661%,663%,761%,763%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">150</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_662_661">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_662_661" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_662_661</field>
       <field name="description">b) sur éléments de l'actif circulant</field>
       <field name="expression">-balp[634%,635%,662%,762%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">160</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_622_621">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_622_621" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_622_621</field>
       <field name="description">8 Autres charges d’exploitation</field>
-      <field name="expression">-balp[64%,68%,69%]</field>
-      <field name="suffix">€</field>
+      <field name="expression">-balp[64%,69%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">170</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_716_715">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_716_715" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_716_715</field>
       <field name="description">9 Produits provenant de participations</field>
       <field name="expression">ecdf_718_717 + ecdf_720_719</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">180</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_718_717">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_718_717" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_718_717</field>
       <field name="description">a) provenant d’entreprises liées</field>
       <field name="expression">-balp[75111%,75112%,7521%,7522%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">190</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_720_719">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_720_719" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_720_719</field>
       <field name="description">b) provenant d'autres participations</field>
       <field name="expression">-balp[75113%,75114%,75115%,75116%,75117%,7512%,7523%,7524%,7525%,7526%,7527%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">200</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_722_721">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_722_721" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_722_721</field>
       <field name="description">10 Produits provenant d'autres valeurs mobilières, d'autres titres et de créances de l'actif immobilisé</field>
       <field name="expression">ecdf_724_723 + ecdf_726_725</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">210</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_724_723">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_724_723" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_724_723</field>
       <field name="description">a) provenant d’entreprises liées</field>
       <field name="expression">-balp[7531%,75331%,75411%,75481%,7641%,7642%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">220</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_726_725">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_726_725" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_726_725</field>
       <field name="description">b) autres produits ne figurant pas sous a)</field>
       <field name="expression">-balp[7532%,75332%,75333%,75338%,7534%,75412%,75413%,75418%,75482%,75483%,75488%,7643%,7644%,7645%,7646%,7647%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">230</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_728_727">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_728_727" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_728_727</field>
       <field name="description">11 Autres intérêts et autres produits financiers</field>
       <field name="expression">ecdf_730_729 + ecdf_732_731</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">240</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_730_729">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_730_729" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_730_729</field>
       <field name="description">a) provenant d’entreprises liées</field>
       <field name="expression">-balp[7554%,7651%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">250</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_732_731">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_732_731" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_732_731</field>
       <field name="description">b) autres intérêts et produits financiers</field>
       <field name="expression">-balp[7552%,7553%,7555%,7556%,7558%,756%,758%,7652%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">260</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_664_663">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_664_663" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_664_663</field>
       <field name="description">12 Quote-part dans le résultat des entreprises mises en équivalence</field>
       <field name="expression">-balp[657%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">270</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_666_665">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_666_665" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_666_665</field>
       <field name="description">13 Corrections de valeur sur immobilisations financières et sur valeurs mobilières faisant partie de l'actif circulant</field>
       <field name="expression">-balp[664%,665%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">280</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_628_627">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_628_627" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_628_627</field>
       <field name="description">14 Intérêts et autres charges financières</field>
       <field name="expression">ecdf_630_629 + ecdf_632_631</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">290</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_630_629">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_630_629" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_630_629</field>
       <field name="description">a) concernant des entreprises liées</field>
       <field name="expression">-balp[6554%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">300</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_632_631">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_632_631" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_632_631</field>
       <field name="description">b) autres intérêts et charges financières</field>
       <field name="expression">-balp[654%,6551%,6552%,6553%,6555%,6556%,6558%,656%,658%,659%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
-      <field name="default_css_style"/>
+      <field name="suffix">€</field>
+      <field name="default_css_style"></field>
       <field name="sequence">310</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_636_635">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_636_635" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_636_635</field>
       <field name="description">15 Impôts sur le résultat</field>
       <field name="expression">-balp[67%,77%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">320</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_668_667">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_668_667" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_668_667</field>
       <field name="description">16 Résultat après impôts sur le résultat</field>
       <field name="expression">ecdf_702_701 + ecdf_704_703 + ecdf_706_705 + ecdf_714_713 + ecdf_672_671 + ecdf_606_605 + ecdf_658_657 + ecdf_622_621 + ecdf_716_715 + ecdf_722_721 + ecdf_728_727 + ecdf_664_663 + ecdf_666_665 +ecdf_628_627 + ecdf_636_635</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">330</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_638_637">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_638_637" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_638_637</field>
       <field name="description">17 Autres impôts ne figurant pas sous les postes 1. à 16.</field>
       <field name="expression">-balp[68%,78%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">340</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_670_669">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_ecdf_670_669" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_670_669</field>
       <field name="description">18 Résultat de l'exercice</field>
       <field name="expression">ecdf_668_667 + ecdf_638_637</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">350</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_res_check">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_res_check" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">res_check</field>
       <field name="description">Résultat de l'exercice (check 6+7)</field>
       <field name="expression">-balp[6%,7%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">360</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_pl_2016_res_to_142">
-      <field ref="mis_report_pl_2016" name="report_id"/>
+    <record id="mis_report_pl_2016_res_to_142" model="mis.report.kpi">
+      <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">res_to_142</field>
       <field name="description">Résultat de l'exercice à transférer au 142</field>
       <field name="expression">-balp[6%,7%,869%,879%]</field>
-      <field name="suffix">€</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
+      <field name="suffix">€</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">370</field>
     </record>

--- a/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
@@ -44,7 +44,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_714_713</field>
       <field name="description">4 Autres produits d'exploitation</field>
-      <field name="expression">-balp[74%,768%,769%]</field>
+      <field name="expression">-balp[74%,763%,7681%,7682%,7683%,7684%,7685%,7688%,769%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -165,7 +165,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_660_659</field>
       <field name="description">a) sur frais d'établissement et sur immobilisations corporelles et incorporelles</field>
-      <field name="expression">-balp[631%,632%,633%,661%,663%,761%,763%]</field>
+      <field name="expression">-balp[631%,632%,633%,661%,761%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -187,7 +187,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_622_621</field>
       <field name="description">8 Autres charges d’exploitation</field>
-      <field name="expression">-balp[64%,69%]</field>
+      <field name="expression">-balp[64%,663%,668%,69%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -209,7 +209,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_718_717</field>
       <field name="description">a) provenant d’entreprises liées</field>
-      <field name="expression">-balp[75111%,75112%,7521%,7522%]</field>
+      <field name="expression">-balp[75111%,75112%,7521%,7522%,7641%,7642%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -220,7 +220,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_720_719</field>
       <field name="description">b) provenant d'autres participations</field>
-      <field name="expression">-balp[75113%,75114%,75115%,75116%,75117%,7512%,7523%,7524%,7525%,7526%,7527%]</field>
+      <field name="expression">-balp[75113%,75114%,75115%,75116%,75117%,7512%,7523%,7524%,7525%,7526%,7527%,7643%,7644%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -242,7 +242,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_724_723</field>
       <field name="description">a) provenant d’entreprises liées</field>
-      <field name="expression">-balp[7531%,75331%,75411%,75481%,7641%,7642%]</field>
+      <field name="expression">-balp[7531%,75331%,75411%,75481%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -253,7 +253,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_726_725</field>
       <field name="description">b) autres produits ne figurant pas sous a)</field>
-      <field name="expression">-balp[7532%,75332%,75333%,75338%,7534%,75412%,75413%,75418%,75482%,75483%,75488%,7643%,7644%,7645%,7646%,7647%]</field>
+      <field name="expression">-balp[7532%,75332%,75333%,75338%,7534%,75412%,75413%,75418%,75482%,75483%,75488%,7645%,7646%,7647%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -286,7 +286,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_732_731</field>
       <field name="description">b) autres intérêts et produits financiers</field>
-      <field name="expression">-balp[7552%,7553%,7555%,7556%,7558%,756%,758%,7652%]</field>
+      <field name="expression">-balp[7552%,7553%,7555%,7556%,7558%,756%,758%,7652%,7686%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -308,7 +308,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_666_665</field>
       <field name="description">13 Corrections de valeur sur immobilisations financières et sur valeurs mobilières faisant partie de l'actif circulant</field>
-      <field name="expression">-balp[664%,665%]</field>
+      <field name="expression">-balp[651%,653%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -330,7 +330,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_630_629</field>
       <field name="description">a) concernant des entreprises liées</field>
-      <field name="expression">-balp[6554%]</field>
+      <field name="expression">-balp[6541%,6554%,6641%,6642%,6651%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
@@ -341,7 +341,7 @@
       <field name="report_id" ref="mis_report_pl_2016"></field>
       <field name="name">ecdf_632_631</field>
       <field name="description">b) autres intérêts et charges financières</field>
-      <field name="expression">-balp[654%,6551%,6552%,6553%,6555%,6556%,6558%,656%,658%,659%]</field>
+      <field name="expression">-balp[6542%,6543%,6548%,6551%,6552%,6553%,6555%,6556%,6558%,656%,658%,659%,6643%,6644%,6645%,6646%,6647%,6652%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>

--- a/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 ACSONE SA/NV
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<openerp>
+  <data>
+    <record model="mis.report" id="mis_report_pl_2016">
+      <field name="name">Luxembourg Profit &amp; Loss (ecdf 2016-2017)</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_702_701">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_702_701</field>
+      <field name="description">1 Chiffre d'affaires net</field>
+      <field name="expression">-balp[70%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">10</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_704_703">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_704_703</field>
+      <field name="description">2 Variation du stock de produits finis et en cours de fabrication</field>
+      <field name="expression">-balp[71%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">20</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_706_705">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_706_705</field>
+      <field name="description">3 Travaux effectués par l'entreprise pour elle-même et portés à l'actif</field>
+      <field name="expression">-balp[72%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">30</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_714_713">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_714_713</field>
+      <field name="description">4 Autres produits d'exploitation</field>
+      <field name="expression">-balp[74%,768%,769%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">40</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_672_671">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_672_671</field>
+      <field name="description">5 Matières premières et consommables et autres charges externes</field>
+      <field name="expression">ecdf_602_601 + ecdf_604_603</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">50</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_602_601">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_602_601</field>
+      <field name="description">a) Matières premières et consommables</field>
+      <field name="expression">-balp[60%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">60</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_604_603">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_604_603</field>
+      <field name="description">b) Autres charges externes</field>
+      <field name="expression">-balp[61%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">70</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_606_605">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_606_605</field>
+      <field name="description">6 Frais de personnel</field>
+      <field name="expression">ecdf_608_607 + ecdf_610_609 + ecdf_614_613</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">80</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_608_607">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_608_607</field>
+      <field name="description">a) Salaires et traitements</field>
+      <field name="expression">-balp[621%,622%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">90</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_610_609">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_610_609</field>
+      <field name="description">b) Charges sociales</field>
+      <field name="expression">ecdf_654_653 + ecdf_656_655</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">100</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_654_653">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_654_653</field>
+      <field name="description">i) couvrant les pensions</field>
+      <field name="expression">-balp[624%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">110</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_656_655">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_656_655</field>
+      <field name="description">ii) autres charges sociales</field>
+      <field name="expression">-balp[623%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">120</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_614_613">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_614_613</field>
+      <field name="description">c) Autres frais de personnel</field>
+      <field name="expression">-balp[628%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">130</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_658_657">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_658_657</field>
+      <field name="description">7 Corrections de valeur</field>
+      <field name="expression">ecdf_660_659 + ecdf_662_661</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">140</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_660_659">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_660_659</field>
+      <field name="description">a) sur frais d'établissement et sur immobilisations corporelles et incorporelles</field>
+      <field name="expression">-balp[631%,632%,633%,661%,663%,761%,763%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">150</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_662_661">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_662_661</field>
+      <field name="description">b) sur éléments de l'actif circulant</field>
+      <field name="expression">-balp[634%,635%,662%,762%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">160</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_622_621">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_622_621</field>
+      <field name="description">8 Autres charges d’exploitation</field>
+      <field name="expression">-balp[64%,68%,69%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">170</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_716_715">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_716_715</field>
+      <field name="description">9 Produits provenant de participations</field>
+      <field name="expression">ecdf_718_717 + ecdf_720_719</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">180</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_718_717">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_718_717</field>
+      <field name="description">a) provenant d’entreprises liées</field>
+      <field name="expression">-balp[75111%,75112%,7521%,7522%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">190</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_720_719">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_720_719</field>
+      <field name="description">b) provenant d'autres participations</field>
+      <field name="expression">-balp[75113%,75114%,75115%,75116%,75117%,7512%,7523%,7524%,7525%,7526%,7527%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">200</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_722_721">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_722_721</field>
+      <field name="description">10 Produits provenant d'autres valeurs mobilières, d'autres titres et de créances de l'actif immobilisé</field>
+      <field name="expression">ecdf_724_723 + ecdf_726_725</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">210</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_724_723">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_724_723</field>
+      <field name="description">a) provenant d’entreprises liées</field>
+      <field name="expression">-balp[7531%,75331%,75411%,75481%,7641%,7642%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">220</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_726_725">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_726_725</field>
+      <field name="description">b) autres produits ne figurant pas sous a)</field>
+      <field name="expression">-balp[7532%,75332%,75333%,75338%,7534%,75412%,75413%,75418%,75482%,75483%,75488%,7643%,7644%,7645%,7646%,7647%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">230</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_728_727">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_728_727</field>
+      <field name="description">11 Autres intérêts et autres produits financiers</field>
+      <field name="expression">ecdf_730_729 + ecdf_732_731</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">240</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_730_729">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_730_729</field>
+      <field name="description">a) provenant d’entreprises liées</field>
+      <field name="expression">-balp[7554%,7651%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">250</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_732_731">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_732_731</field>
+      <field name="description">b) autres intérêts et produits financiers</field>
+      <field name="expression">-balp[7552%,7553%,7555%,7556%,7558%,756%,758%,7652%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">260</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_664_663">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_664_663</field>
+      <field name="description">12 Quote-part dans le résultat des entreprises mises en équivalence</field>
+      <field name="expression">-balp[657%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">270</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_666_665">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_666_665</field>
+      <field name="description">13 Corrections de valeur sur immobilisations financières et sur valeurs mobilières faisant partie de l'actif circulant</field>
+      <field name="expression">-balp[664%,665%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">280</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_628_627">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_628_627</field>
+      <field name="description">14 Intérêts et autres charges financières</field>
+      <field name="expression">ecdf_630_629 + ecdf_632_631</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">290</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_630_629">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_630_629</field>
+      <field name="description">a) concernant des entreprises liées</field>
+      <field name="expression">-balp[6554%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">300</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_632_631">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_632_631</field>
+      <field name="description">b) autres intérêts et charges financières</field>
+      <field name="expression">-balp[654%,6551%,6552%,6553%,6555%,6556%,6558%,656%,658%,659%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style"/>
+      <field name="sequence">310</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_636_635">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_636_635</field>
+      <field name="description">15 Impôts sur le résultat</field>
+      <field name="expression">-balp[67%,77%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">320</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_668_667">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_668_667</field>
+      <field name="description">16 Résultat après impôts sur le résultat</field>
+      <field name="expression">ecdf_702_701 + ecdf_704_703 + ecdf_706_705 + ecdf_714_713 + ecdf_672_671 + ecdf_606_605 + ecdf_658_657 + ecdf_622_621 + ecdf_716_715 + ecdf_722_721 + ecdf_728_727 + ecdf_664_663 + ecdf_666_665 +ecdf_628_627 + ecdf_636_635</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">330</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_638_637">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_638_637</field>
+      <field name="description">17 Autres impôts ne figurant pas sous les postes 1. à 16.</field>
+      <field name="expression">-balp[68%,78%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">340</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_ecdf_670_669">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">ecdf_670_669</field>
+      <field name="description">18 Résultat de l'exercice</field>
+      <field name="expression">ecdf_668_667 + ecdf_638_637</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-weight: bold</field>
+      <field name="sequence">350</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_res_check">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">res_check</field>
+      <field name="description">Résultat de l'exercice (check 6+7)</field>
+      <field name="expression">-balp[6%,7%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">360</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_pl_2016_res_to_142">
+      <field ref="mis_report_pl_2016" name="report_id"/>
+      <field name="name">res_to_142</field>
+      <field name="description">Résultat de l'exercice à transférer au 142</field>
+      <field name="expression">-balp[6%,7%,869%,879%]</field>
+      <field name="suffix">€</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="default_css_style">font-style: italic</field>
+      <field name="sequence">370</field>
+    </record>
+  </data>
+</openerp>

--- a/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
+++ b/l10n_lu_mis_reports/data/mis_report_pl_2016.xml
@@ -15,6 +15,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">10</field>
     </record>
@@ -26,6 +27,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">20</field>
     </record>
@@ -37,6 +39,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">30</field>
     </record>
@@ -48,6 +51,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">40</field>
     </record>
@@ -59,6 +63,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">50</field>
     </record>
@@ -70,6 +75,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">60</field>
     </record>
@@ -81,6 +87,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">70</field>
     </record>
@@ -92,6 +99,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">80</field>
     </record>
@@ -103,6 +111,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">90</field>
     </record>
@@ -114,6 +123,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">100</field>
     </record>
@@ -125,6 +135,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">110</field>
     </record>
@@ -136,6 +147,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">120</field>
     </record>
@@ -147,6 +159,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">130</field>
     </record>
@@ -158,6 +171,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">140</field>
     </record>
@@ -169,6 +183,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">150</field>
     </record>
@@ -180,6 +195,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">160</field>
     </record>
@@ -191,6 +207,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">170</field>
     </record>
@@ -202,6 +219,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">180</field>
     </record>
@@ -213,6 +231,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">190</field>
     </record>
@@ -224,6 +243,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">200</field>
     </record>
@@ -235,6 +255,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">210</field>
     </record>
@@ -246,6 +267,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">220</field>
     </record>
@@ -257,6 +279,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">230</field>
     </record>
@@ -268,6 +291,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">240</field>
     </record>
@@ -279,6 +303,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">250</field>
     </record>
@@ -290,6 +315,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">260</field>
     </record>
@@ -301,6 +327,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">270</field>
     </record>
@@ -312,6 +339,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">280</field>
     </record>
@@ -323,6 +351,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">290</field>
     </record>
@@ -334,6 +363,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">300</field>
     </record>
@@ -345,6 +375,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style"></field>
       <field name="sequence">310</field>
     </record>
@@ -356,6 +387,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">320</field>
     </record>
@@ -367,6 +399,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">330</field>
     </record>
@@ -378,6 +411,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">340</field>
     </record>
@@ -389,6 +423,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-weight: bold</field>
       <field name="sequence">350</field>
     </record>
@@ -400,6 +435,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">360</field>
     </record>
@@ -411,6 +447,7 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="suffix">€</field>
+      <field name="dp">2</field>
       <field name="default_css_style">font-style: italic</field>
       <field name="sequence">370</field>
     </record>


### PR DESCRIPTION
Add mis report templates for P&L and Balance Sheet, 2016-2017 model.
Update l10n_lu_ecdf to use them. Disable abbreviated reports
in the ecdf wizard as we have not updated them.